### PR TITLE
refactor(frontend): standardize UI components and design tokens

### DIFF
--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode, type ContextType } from 'react';
+import { Alert, Button } from '../ui';
 import { I18nContext } from '../../i18n';
 
 interface Props {
@@ -33,23 +34,25 @@ class ErrorBoundary extends Component<Props, State> {
       const t = this.context.t;
       return (
         this.props.fallback || (
-          <div className="rounded-lg bg-[#272729] p-5 text-white">
-            <h2
-              className="text-lg font-semibold leading-tight tracking-[0.231px]"
-              style={{ fontFamily: 'var(--font-display)' }}
-            >
-              {t('components.errorBoundary.title')}
-            </h2>
-            <p className="mt-2 text-sm leading-relaxed text-white/70 tracking-[-0.224px]">
-              {this.state.error?.message}
-            </p>
-            <button
-              onClick={() => this.setState({ hasError: false, error: null })}
-              className="mt-4 rounded-lg bg-[var(--apple-blue)] px-4 py-2 text-sm font-medium text-white transition hover:bg-[var(--apple-blue-hover)]"
-            >
-              {t('components.errorBoundary.retry')}
-            </button>
-          </div>
+          <Alert variant="error">
+            <div className="space-y-2">
+              <h2
+                className="text-lg font-semibold leading-tight tracking-[0.231px]"
+                style={{ fontFamily: 'var(--font-display)' }}
+              >
+                {t('components.errorBoundary.title')}
+              </h2>
+              <p className="text-sm leading-relaxed text-white/70 tracking-[-0.224px]">
+                {this.state.error?.message}
+              </p>
+              <Button
+                variant="primary"
+                onClick={() => this.setState({ hasError: false, error: null })}
+              >
+                {t('components.errorBoundary.retry')}
+              </Button>
+            </div>
+          </Alert>
         )
       );
     }

--- a/frontend/src/components/dashboard/HealthStatusBar.tsx
+++ b/frontend/src/components/dashboard/HealthStatusBar.tsx
@@ -1,17 +1,10 @@
+import { Alert, StatusDot } from '../ui';
 import type { SystemHealth } from '../../types';
 import { useT } from '../../i18n';
 
 interface Props {
   health: SystemHealth | undefined;
   isLoading: boolean;
-}
-
-function StatusDot({ active }: { active: boolean; color?: string }) {
-  return (
-    <span
-      className={`inline-block h-2 w-2 rounded-full ${active ? 'bg-[#34c759]' : 'bg-[#ff3b30]'}`}
-    />
-  );
 }
 
 function StatusItem({
@@ -25,7 +18,7 @@ function StatusItem({
 }) {
   return (
     <div className="flex items-center gap-2">
-      <StatusDot active={active} />
+      <StatusDot status={active ? 'success' : 'error'} />
       <span className="text-sm tracking-[-0.224px] text-[var(--text-secondary)]">
         {label} <span className="font-medium text-[var(--text)]">{text}</span>
       </span>
@@ -46,10 +39,12 @@ function HealthStatusBar({ health, isLoading }: Props) {
 
   if (!health) {
     return (
-      <div className="flex items-center gap-2 rounded-lg bg-[#ffebee] px-4 py-3 text-sm text-[#c62828]">
-        <span className="inline-block h-2 w-2 rounded-full bg-[#ff3b30]" />
-        {t('components.healthStatusBar.unable')}
-      </div>
+      <Alert variant="error">
+        <div className="flex items-center gap-2">
+          <StatusDot status="error" />
+          {t('components.healthStatusBar.unable')}
+        </div>
+      </Alert>
     );
   }
 

--- a/frontend/src/components/environment/EnvironmentSelectorPanel.tsx
+++ b/frontend/src/components/environment/EnvironmentSelectorPanel.tsx
@@ -1,3 +1,4 @@
+import { Badge, SectionCard, SectionHeader, Select, StatusDot } from '../ui';
 import type { EnvironmentRecord } from '../../types';
 import { useT } from '../../i18n';
 
@@ -23,40 +24,27 @@ function EnvironmentSelectorPanel({
   const t = useT();
 
   return (
-    <section className="space-y-5 rounded-xl bg-[var(--surface)] p-6 shadow-sm">
+    <SectionCard>
       <div className="space-y-2">
-        <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--apple-blue)]">
-          {t('components.environmentSelector.eyebrow')}
-        </p>
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div className="space-y-1">
-            <h2
-              className="text-xl font-semibold leading-tight tracking-[0.231px] text-[var(--text)]"
-              style={{ fontFamily: 'var(--font-display)' }}
-            >
-              {t('components.environmentSelector.title')}
-            </h2>
-            <p className="max-w-xl text-sm leading-relaxed tracking-[-0.224px] text-[var(--text-secondary)]">
-              {t('components.environmentSelector.description')}
-            </p>
-          </div>
-          <div className="inline-flex items-center gap-2 rounded-full bg-[var(--bg-tertiary)] px-3 py-1.5 text-sm font-medium text-[var(--text)]">
-            {selectedEnvironment ? (
-              <span className="inline-flex items-center gap-2">
-                <span className="h-2 w-2 rounded-full bg-[#34c759]" />
-                <span>{selectedEnvironment.alias}</span>
-                {selectedEnvironment.is_seed ? (
-                  <span className="rounded-full bg-[var(--apple-blue)]/10 px-2 py-0.5 text-xs font-semibold text-[var(--apple-blue)]">
-                    {t('common.default')}
-                  </span>
-                ) : null}
-              </span>
-            ) : (
-              <span className="text-[var(--text-tertiary)]">
-                {t('components.environmentSelector.selectedNone')}
-              </span>
-            )}
-          </div>
+        <SectionHeader
+          title={t('components.environmentSelector.title')}
+          description={t('components.environmentSelector.description')}
+          size="md"
+        />
+        <div className="inline-flex items-center gap-2 rounded-full bg-[var(--bg-tertiary)] px-3 py-1.5 text-sm font-medium text-[var(--text)]">
+          {selectedEnvironment ? (
+            <span className="inline-flex items-center gap-2">
+              <StatusDot status="success" />
+              <span>{selectedEnvironment.alias}</span>
+              {selectedEnvironment.is_seed ? (
+                <Badge>{t('common.default')}</Badge>
+              ) : null}
+            </span>
+          ) : (
+            <span className="text-[var(--text-tertiary)]">
+              {t('components.environmentSelector.selectedNone')}
+            </span>
+          )}
         </div>
       </div>
 
@@ -65,11 +53,11 @@ function EnvironmentSelectorPanel({
           <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
             {t('components.environmentSelector.activeLabel')}
           </span>
-          <select
+          <Select
             value={selectedEnvironmentId ?? ''}
             onChange={(event) => onSelectEnvironment(event.target.value)}
             disabled={!hasEnvironments || isLoading}
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15 disabled:cursor-not-allowed disabled:bg-[var(--bg-tertiary)] disabled:text-[var(--text-tertiary)]"
+            className="disabled:cursor-not-allowed disabled:bg-[var(--bg-tertiary)] disabled:text-[var(--text-tertiary)]"
           >
             {!hasEnvironments ? (
               <option value="">{t('components.environmentSelector.noAvailable')}</option>
@@ -79,7 +67,7 @@ function EnvironmentSelectorPanel({
                 {environment.alias} · {environment.display_name}
               </option>
             ))}
-          </select>
+          </Select>
         </label>
 
         <div className="space-y-3 rounded-lg bg-[var(--bg-secondary)] p-4">
@@ -132,7 +120,7 @@ function EnvironmentSelectorPanel({
           )}
         </div>
       </div>
-    </section>
+    </SectionCard>
   );
 }
 

--- a/frontend/src/components/file-browser/FileViewer.tsx
+++ b/frontend/src/components/file-browser/FileViewer.tsx
@@ -3,12 +3,12 @@ import type { FileReadResponse } from '../../types';
 
 const MonacoEditor = lazy(() => import('@monaco-editor/react'));
 
-interface FileViewerProps {
+interface Props {
   file: FileReadResponse | null;
   isLoading: boolean;
 }
 
-export default function FileViewer({ file, isLoading }: FileViewerProps) {
+export default function FileViewer({ file, isLoading }: Props) {
   if (isLoading) {
     return (
       <div className="flex h-full items-center justify-center text-sm text-[var(--text-tertiary)]">

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -3,3 +3,4 @@ export * from './environment';
 export * from './dashboard';
 export * from './file-browser';
 export * from './terminal';
+export * from './ui';

--- a/frontend/src/components/terminal/TerminalBenchCardView.tsx
+++ b/frontend/src/components/terminal/TerminalBenchCardView.tsx
@@ -1,3 +1,4 @@
+import { Button, SectionCard, SectionHeader, StatusDot } from '../ui';
 import TerminalSessionConsole from './TerminalSessionConsole';
 import type { TerminalSessionStatus } from '../../types';
 import { useT } from '../../i18n';
@@ -55,65 +56,56 @@ function TerminalBenchCardView({
   };
   const hasRuntimeError = loadError !== null || detail !== null;
 
-  const statusColor =
-    status === 'running'
-      ? 'bg-[#34c759]'
-      : status === 'failed'
-        ? 'bg-[#ff3b30]'
-        : status === 'starting' || status === 'stopping'
-          ? 'bg-[#ff9500]'
-          : 'bg-[var(--text-tertiary)]';
+  const statusMap: Record<TerminalSessionStatus, 'success' | 'error' | 'warning' | 'idle'> = {
+    idle: 'idle',
+    starting: 'warning',
+    running: 'success',
+    stopping: 'warning',
+    failed: 'error',
+  };
 
   return (
-    <section className="space-y-5 rounded-xl bg-[var(--surface)] p-6 shadow-sm">
+    <SectionCard>
       <div className="space-y-2">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--apple-blue)]">
-              {t('components.terminalBench.eyebrow')}
-            </p>
-            <h2
-              className="mt-1 text-xl font-semibold leading-tight tracking-[0.231px] text-[var(--text)]"
-              style={{ fontFamily: 'var(--font-display)' }}
-            >
-              {t('components.terminalBench.title')}
-            </h2>
-          </div>
+          <SectionHeader
+            eyebrow={t('components.terminalBench.eyebrow')}
+            title={t('components.terminalBench.title')}
+            description={t('components.terminalBench.description')}
+            size="md"
+          />
           <div className="inline-flex items-center gap-2 rounded-full bg-[var(--bg-tertiary)] px-3 py-1.5 text-sm font-medium text-[var(--text)]">
-            <span className={`h-2 w-2 rounded-full ${statusColor}`} />
+            <StatusDot status={statusMap[status]} />
             {t('components.terminalBench.statusPrefix')} {statusLabel[status]}
           </div>
         </div>
-        <p className="max-w-3xl text-sm leading-relaxed tracking-[-0.224px] text-[var(--text-secondary)]">
-          {t('components.terminalBench.description')}
-        </p>
       </div>
 
       <div className="flex flex-wrap items-center gap-3">
-        <button
-          type="button"
+        <Button
+          variant="primary"
           onClick={onAttach}
           disabled={!canAttach}
-          className="rounded-lg bg-[var(--apple-blue)] px-4 py-2 text-sm font-medium text-white transition hover:bg-[var(--apple-blue-hover)] disabled:cursor-not-allowed disabled:opacity-40"
+          isLoading={isAttaching}
         >
           {isAttaching ? t('components.terminalBench.attaching') : t('components.terminalBench.attach')}
-        </button>
-        <button
-          type="button"
+        </Button>
+        <Button
+          variant="secondary"
           onClick={onDetach}
           disabled={!canDetach}
-          className="rounded-lg border border-[var(--border)] bg-[var(--bg)] px-4 py-2 text-sm font-medium text-[var(--text)] transition hover:bg-[var(--bg-secondary)] disabled:cursor-not-allowed disabled:opacity-40"
+          isLoading={isDetaching}
         >
           {isDetaching ? t('components.terminalBench.detaching') : t('components.terminalBench.detach')}
-        </button>
-        <button
-          type="button"
+        </Button>
+        <Button
+          variant="secondary"
           onClick={onReset}
           disabled={!canReset}
-          className="rounded-lg border border-[var(--border)] bg-[var(--bg)] px-4 py-2 text-sm font-medium text-[var(--text)] transition hover:bg-[var(--bg-secondary)] disabled:cursor-not-allowed disabled:opacity-40"
+          isLoading={isResetting}
         >
           {isResetting ? t('components.terminalBench.resetting') : t('components.terminalBench.resetSession')}
-        </button>
+        </Button>
       </div>
 
       <div className="space-y-3 rounded-lg bg-[var(--bg-secondary)] p-4">
@@ -172,7 +164,7 @@ function TerminalBenchCardView({
         status={status}
         onDisconnected={onTerminalDisconnected}
       />
-    </section>
+    </SectionCard>
   );
 }
 

--- a/frontend/src/components/ui/Alert.tsx
+++ b/frontend/src/components/ui/Alert.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  variant?: 'error' | 'warning' | 'success';
+  className?: string;
+}
+
+const variantClasses: Record<NonNullable<Props['variant']>, string> = {
+  error: 'border-[#ff3b30]/20 bg-[#ffebee] text-[#c62828]',
+  warning: 'border-[#ff9500]/20 bg-[#fff3e0] text-[#e65100]',
+  success: 'border-[#34c759]/20 bg-[#e8f5e9] text-[#2e7d32]',
+};
+
+function Alert({ children, variant = 'error', className = '' }: Props) {
+  return (
+    <div className={['rounded-lg border p-3 text-sm', variantClasses[variant], className].join(' ')}>
+      {children}
+    </div>
+  );
+}
+
+export default Alert;

--- a/frontend/src/components/ui/Badge.tsx
+++ b/frontend/src/components/ui/Badge.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  variant?: 'default' | 'outline' | 'secondary';
+  className?: string;
+}
+
+const variantClasses: Record<NonNullable<Props['variant']>, string> = {
+  default: 'rounded-full bg-[var(--apple-blue)]/10 px-2 py-0.5 text-xs font-semibold text-[var(--apple-blue)]',
+  outline: 'rounded-full border border-[var(--border)] bg-transparent px-2 py-0.5 text-xs font-semibold text-[var(--text-secondary)]',
+  secondary: 'rounded-full bg-[var(--bg-secondary)] px-2 py-0.5 text-xs font-semibold text-[var(--text)]',
+};
+
+function Badge({ children, variant = 'default', className = '' }: Props) {
+  return <span className={[variantClasses[variant], className].join(' ')}>{children}</span>;
+}
+
+export default Badge;

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,44 @@
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from 'react';
+
+interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary' | 'danger' | 'ghost';
+  size?: 'sm' | 'md';
+  isLoading?: boolean;
+  children: ReactNode;
+}
+
+const variantClasses: Record<NonNullable<Props['variant']>, string> = {
+  primary:
+    'rounded-lg bg-[var(--apple-blue)] px-4 py-2 text-sm font-medium text-white transition hover:bg-[var(--apple-blue-hover)] disabled:cursor-not-allowed disabled:opacity-40',
+  secondary:
+    'rounded-lg border border-[var(--border)] bg-[var(--bg)] px-4 py-2 text-sm font-medium text-[var(--text)] transition hover:bg-[var(--bg-secondary)] disabled:cursor-not-allowed disabled:opacity-40',
+  danger:
+    'rounded-lg bg-[#ff3b30] px-4 py-2 text-sm font-medium text-white transition hover:bg-[#d32f2f] disabled:cursor-not-allowed disabled:opacity-40',
+  ghost:
+    'rounded-lg px-4 py-2 text-sm font-medium text-[var(--muted-foreground)] transition hover:bg-[var(--bg-secondary)] hover:text-[var(--text)] disabled:cursor-not-allowed disabled:opacity-40',
+};
+
+const sizeClasses: Record<NonNullable<Props['size']>, string> = {
+  sm: 'px-3 py-1.5 text-xs',
+  md: '',
+};
+
+const Button = forwardRef<HTMLButtonElement, Props>(function Button(
+  { variant = 'primary', size = 'md', isLoading = false, children, className = '', disabled, ...rest },
+  ref
+) {
+  const base = variantClasses[variant];
+  const sizeOverride = size === 'sm' ? sizeClasses.sm : '';
+  return (
+    <button
+      ref={ref}
+      className={[base, size === 'sm' ? sizeOverride : '', className].join(' ')}
+      disabled={disabled || isLoading}
+      {...rest}
+    >
+      {isLoading ? 'Loading…' : children}
+    </button>
+  );
+});
+
+export default Button;

--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react';
+
+interface Props {
+  message: string;
+  icon?: ReactNode;
+  variant?: 'dashed' | 'subtle';
+}
+
+const variantClasses: Record<NonNullable<Props['variant']>, string> = {
+  dashed: 'rounded-lg border border-dashed border-[var(--border)] bg-[var(--bg-secondary)]',
+  subtle: 'rounded-lg bg-[var(--bg-secondary)]',
+};
+
+function EmptyState({ message, icon, variant = 'dashed' }: Props) {
+  return (
+    <div className={['flex flex-1 items-center justify-center', variantClasses[variant]].join(' ')}>
+      <div className="text-center">
+        {icon ? <div className="mb-2 flex justify-center text-[var(--text-tertiary)]">{icon}</div> : null}
+        <p className="text-sm text-[var(--text-tertiary)]">{message}</p>
+      </div>
+    </div>
+  );
+}
+
+export default EmptyState;

--- a/frontend/src/components/ui/FormField.tsx
+++ b/frontend/src/components/ui/FormField.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+
+interface Props {
+  label: string;
+  error?: string;
+  children: ReactNode;
+}
+
+function FormField({ label, error, children }: Props) {
+  return (
+    <label className="space-y-2">
+      <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">{label}</span>
+      {children}
+      {error ? <p className="text-xs text-[#ff3b30]">{error}</p> : null}
+    </label>
+  );
+}
+
+export default FormField;

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -1,0 +1,28 @@
+import { forwardRef, type InputHTMLAttributes } from 'react';
+
+interface Props extends InputHTMLAttributes<HTMLInputElement> {
+  error?: string;
+}
+
+const Input = forwardRef<HTMLInputElement, Props>(function Input(
+  { error, className = '', ...rest },
+  ref
+) {
+  const errorClasses = error
+    ? 'border-[#ff3b30] focus:border-[#ff3b30] focus:ring-[#ff3b30]/15'
+    : 'border-[var(--border)] focus:border-[var(--apple-blue)] focus:ring-[var(--apple-blue)]/15';
+  return (
+    <input
+      ref={ref}
+      className={[
+        'w-full rounded-lg bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition',
+        errorClasses,
+        'focus:ring-2',
+        className,
+      ].join(' ')}
+      {...rest}
+    />
+  );
+});
+
+export default Input;

--- a/frontend/src/components/ui/PageHeader.tsx
+++ b/frontend/src/components/ui/PageHeader.tsx
@@ -1,0 +1,28 @@
+interface Props {
+  eyebrow: string;
+  title: string;
+  description?: string;
+}
+
+function PageHeader({ eyebrow, title, description }: Props) {
+  return (
+    <section className="space-y-3">
+      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--apple-blue)]">
+        {eyebrow}
+      </p>
+      <h1
+        className="text-[28px] font-normal leading-tight tracking-[0.196px] text-[var(--text)]"
+        style={{ fontFamily: 'var(--font-display)' }}
+      >
+        {title}
+      </h1>
+      {description ? (
+        <p className="max-w-3xl text-base leading-relaxed tracking-[-0.374px] text-[var(--text-secondary)]">
+          {description}
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+export default PageHeader;

--- a/frontend/src/components/ui/SectionCard.tsx
+++ b/frontend/src/components/ui/SectionCard.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  className?: string;
+}
+
+function SectionCard({ children, className = '' }: Props) {
+  return (
+    <section className={['space-y-5 rounded-xl bg-[var(--surface)] p-6 shadow-sm', className].join(' ')}>
+      {children}
+    </section>
+  );
+}
+
+export default SectionCard;

--- a/frontend/src/components/ui/SectionHeader.tsx
+++ b/frontend/src/components/ui/SectionHeader.tsx
@@ -1,0 +1,34 @@
+interface Props {
+  title: string;
+  description?: string;
+  eyebrow?: string;
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}
+
+function SectionHeader({ title, description, eyebrow, size = 'md', className = '' }: Props) {
+  const titleClasses: Record<NonNullable<Props['size']>, string> = {
+    sm: 'text-base font-semibold leading-tight tracking-[0.231px] text-[var(--text)]',
+    md: 'text-lg font-semibold leading-tight tracking-[0.231px] text-[var(--text)]',
+    lg: 'text-[28px] font-normal leading-tight tracking-[0.196px] text-[var(--text)]',
+  };
+  return (
+    <div className={['space-y-1', className].join(' ')}>
+      {eyebrow ? (
+        <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--apple-blue)]">
+          {eyebrow}
+        </p>
+      ) : null}
+      <h2 className={titleClasses[size]} style={{ fontFamily: 'var(--font-display)' }}>
+        {title}
+      </h2>
+      {description ? (
+        <p className="text-sm leading-relaxed tracking-[-0.224px] text-[var(--text-secondary)]">
+          {description}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+export default SectionHeader;

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -1,0 +1,31 @@
+import { forwardRef, type ReactNode, type SelectHTMLAttributes } from 'react';
+
+interface Props extends SelectHTMLAttributes<HTMLSelectElement> {
+  error?: string;
+  children: ReactNode;
+}
+
+const Select = forwardRef<HTMLSelectElement, Props>(function Select(
+  { error, children, className = '', ...rest },
+  ref
+) {
+  const errorClasses = error
+    ? 'border-[#ff3b30] focus:border-[#ff3b30] focus:ring-[#ff3b30]/15'
+    : 'border-[var(--border)] focus:border-[var(--apple-blue)] focus:ring-[var(--apple-blue)]/15';
+  return (
+    <select
+      ref={ref}
+      className={[
+        'w-full rounded-lg bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition',
+        errorClasses,
+        'focus:ring-2',
+        className,
+      ].join(' ')}
+      {...rest}
+    >
+      {children}
+    </select>
+  );
+});
+
+export default Select;

--- a/frontend/src/components/ui/StatusDot.tsx
+++ b/frontend/src/components/ui/StatusDot.tsx
@@ -1,0 +1,22 @@
+interface Props {
+  status: 'success' | 'error' | 'warning' | 'idle';
+  size?: 'sm' | 'md';
+}
+
+const statusColors: Record<Props['status'], string> = {
+  success: 'bg-[#34c759]',
+  error: 'bg-[#ff3b30]',
+  warning: 'bg-[#ff9500]',
+  idle: 'bg-[var(--text-tertiary)]',
+};
+
+const sizeClasses: Record<NonNullable<Props['size']>, string> = {
+  sm: 'h-1.5 w-1.5',
+  md: 'h-2 w-2',
+};
+
+function StatusDot({ status, size = 'md' }: Props) {
+  return <span className={['inline-block rounded-full', statusColors[status], sizeClasses[size]].join(' ')} />;
+}
+
+export default StatusDot;

--- a/frontend/src/components/ui/Textarea.tsx
+++ b/frontend/src/components/ui/Textarea.tsx
@@ -1,0 +1,28 @@
+import { forwardRef, type TextareaHTMLAttributes } from 'react';
+
+interface Props extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  error?: string;
+}
+
+const Textarea = forwardRef<HTMLTextAreaElement, Props>(function Textarea(
+  { error, className = '', ...rest },
+  ref
+) {
+  const errorClasses = error
+    ? 'border-[#ff3b30] focus:border-[#ff3b30] focus:ring-[#ff3b30]/15'
+    : 'border-[var(--border)] focus:border-[var(--apple-blue)] focus:ring-[var(--apple-blue)]/15';
+  return (
+    <textarea
+      ref={ref}
+      className={[
+        'w-full rounded-lg bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition',
+        errorClasses,
+        'focus:ring-2',
+        className,
+      ].join(' ')}
+      {...rest}
+    />
+  );
+});
+
+export default Textarea;

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -1,0 +1,12 @@
+export { default as Alert } from './Alert';
+export { default as Badge } from './Badge';
+export { default as Button } from './Button';
+export { default as EmptyState } from './EmptyState';
+export { default as FormField } from './FormField';
+export { default as Input } from './Input';
+export { default as PageHeader } from './PageHeader';
+export { default as SectionCard } from './SectionCard';
+export { default as SectionHeader } from './SectionHeader';
+export { default as Select } from './Select';
+export { default as StatusDot } from './StatusDot';
+export { default as Textarea } from './Textarea';

--- a/frontend/src/pages/ContainersPage.tsx
+++ b/frontend/src/pages/ContainersPage.tsx
@@ -1,6 +1,18 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useMemo, useState, type FormEvent } from 'react';
 import {
+  Alert,
+  Badge,
+  Button,
+  FormField,
+  Input,
+  PageHeader,
+  SectionCard,
+  SectionHeader,
+  Select,
+  Textarea,
+} from '../components/ui';
+import {
   createProjectEnvironmentReference,
   createEnvironment,
   deleteProjectEnvironmentReference,
@@ -113,21 +125,12 @@ function EnvironmentEditor({
   };
 
   return (
-    <section className="space-y-5 rounded-xl bg-[var(--surface)] p-6 shadow-sm">
-      <div className="space-y-2">
-        <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--apple-blue)]">
-          {t('components.environmentEditor.eyebrow')}
-        </p>
-        <h2
-          className="text-xl font-semibold leading-tight tracking-[0.231px] text-[var(--text)]"
-          style={{ fontFamily: 'var(--font-display)' }}
-        >
-          {title}
-        </h2>
-        <p className="text-sm leading-relaxed tracking-[-0.224px] text-[var(--text-secondary)]">
-          {t('components.environmentEditor.description')}
-        </p>
-      </div>
+    <SectionCard>
+      <SectionHeader
+        eyebrow={t('components.environmentEditor.eyebrow')}
+        title={title}
+        description={t('components.environmentEditor.description')}
+      />
 
       {activeEnvironment ? (
         <div
@@ -146,261 +149,184 @@ function EnvironmentEditor({
 
       <form className="space-y-5" onSubmit={handleSubmit}>
         <div className="grid gap-4 sm:grid-cols-2">
-          <label className="space-y-2">
-            <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-              {t('components.environmentEditor.alias')}
-            </span>
-            <input
+          <FormField label={t('components.environmentEditor.alias')}>
+            <Input
               required
               value={values.alias}
               onChange={(event) => updateField('alias', event.target.value)}
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
               placeholder={placeholders.alias}
             />
-          </label>
+          </FormField>
 
-          <label className="space-y-2">
-            <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-              {t('components.environmentEditor.displayName')}
-            </span>
-            <input
+          <FormField label={t('components.environmentEditor.displayName')}>
+            <Input
               required
               value={values.display_name}
               onChange={(event) => updateField('display_name', event.target.value)}
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
               placeholder={placeholders.displayName}
             />
-          </label>
+          </FormField>
         </div>
 
-        <label className="space-y-2">
-          <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-            {t('components.environmentEditor.descriptionField')}
-          </span>
-          <textarea
+        <FormField label={t('components.environmentEditor.descriptionField')}>
+          <Textarea
             value={values.description}
             onChange={(event) => updateField('description', event.target.value)}
             rows={3}
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
             placeholder={placeholders.description}
           />
-        </label>
+        </FormField>
 
         <div className="grid gap-4 sm:grid-cols-2">
-          <label className="space-y-2">
-            <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-              {t('components.environmentEditor.host')}
-            </span>
-            <input
+          <FormField label={t('components.environmentEditor.host')}>
+            <Input
               required
               value={values.host}
               onChange={(event) => updateField('host', event.target.value)}
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
               placeholder={placeholders.host}
             />
-          </label>
+          </FormField>
 
-          <label className="space-y-2">
-            <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-              {t('components.environmentEditor.port')}
-            </span>
-            <input
+          <FormField label={t('components.environmentEditor.port')}>
+            <Input
               required
               type="number"
               min={1}
               max={65535}
               value={values.port}
               onChange={(event) => updateField('port', event.target.value)}
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
               placeholder={placeholders.port}
             />
-          </label>
+          </FormField>
         </div>
 
         <div className="grid gap-4 sm:grid-cols-2">
-          <label className="space-y-2">
-            <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-              {t('components.environmentEditor.user')}
-            </span>
-            <input
+          <FormField label={t('components.environmentEditor.user')}>
+            <Input
               value={values.user}
               onChange={(event) => updateField('user', event.target.value)}
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
               placeholder={placeholders.user}
             />
-          </label>
+          </FormField>
 
-          <label className="space-y-2">
-            <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-              {t('components.environmentEditor.authKindLabel')}
-            </span>
-            <select
+          <FormField label={t('components.environmentEditor.authKindLabel')}>
+            <Select
               value={values.auth_kind}
               onChange={(event) => updateField('auth_kind', event.target.value as EnvironmentAuthKind)}
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
             >
               <option value="ssh_key">{authKindLabels.ssh_key}</option>
               <option value="password">{authKindLabels.password}</option>
               <option value="agent">{authKindLabels.agent}</option>
-            </select>
-          </label>
+            </Select>
+          </FormField>
         </div>
 
         <div className="grid gap-4 sm:grid-cols-2">
-          <label className="space-y-2">
-            <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-              {t('components.environmentEditor.identityFile')}
-            </span>
-            <input
+          <FormField label={t('components.environmentEditor.identityFile')}>
+            <Input
               value={values.identity_file}
               onChange={(event) => updateField('identity_file', event.target.value)}
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
               placeholder={placeholders.identityFile}
             />
-          </label>
+          </FormField>
 
-          <label className="space-y-2">
-            <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-              {t('components.environmentEditor.proxyJump')}
-            </span>
-            <input
+          <FormField label={t('components.environmentEditor.proxyJump')}>
+            <Input
               value={values.proxy_jump}
               onChange={(event) => updateField('proxy_jump', event.target.value)}
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
               placeholder={placeholders.proxyJump}
             />
-          </label>
+          </FormField>
         </div>
 
-        <label className="space-y-2">
-          <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-            {t('components.environmentEditor.proxyCommand')}
-          </span>
-          <input
+        <FormField label={t('components.environmentEditor.proxyCommand')}>
+          <Input
             value={values.proxy_command}
             onChange={(event) => updateField('proxy_command', event.target.value)}
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
             placeholder={placeholders.proxyCommand}
           />
-        </label>
+        </FormField>
 
         <div className="grid gap-4 sm:grid-cols-2">
-          <label className="space-y-2">
-            <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-              {t('components.environmentEditor.tags')}
-            </span>
-            <input
+          <FormField label={t('components.environmentEditor.tags')}>
+            <Input
               value={values.tags}
               onChange={(event) => updateField('tags', event.target.value)}
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
               placeholder={placeholders.tags}
             />
-          </label>
+          </FormField>
 
-          <label className="space-y-2">
-            <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-              {t('components.environmentEditor.defaultWorkdir')}
-            </span>
-            <input
+          <FormField label={t('components.environmentEditor.defaultWorkdir')}>
+            <Input
               value={values.default_workdir}
               onChange={(event) => updateField('default_workdir', event.target.value)}
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
               placeholder={placeholders.defaultWorkdir}
             />
-          </label>
+          </FormField>
         </div>
 
         <div className="grid gap-4 sm:grid-cols-2">
-          <label className="space-y-2">
-            <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-              {t('components.environmentEditor.preferredPython')}
-            </span>
-            <input
+          <FormField label={t('components.environmentEditor.preferredPython')}>
+            <Input
               value={values.preferred_python}
               onChange={(event) => updateField('preferred_python', event.target.value)}
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
               placeholder={placeholders.preferredPython}
             />
-          </label>
+          </FormField>
 
-          <label className="space-y-2">
-            <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-              {t('components.environmentEditor.preferredEnvManager')}
-            </span>
-            <input
+          <FormField label={t('components.environmentEditor.preferredEnvManager')}>
+            <Input
               value={values.preferred_env_manager}
               onChange={(event) => updateField('preferred_env_manager', event.target.value)}
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
               placeholder={placeholders.preferredEnvManager}
             />
-          </label>
+          </FormField>
         </div>
 
-        <label className="space-y-2">
-          <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-            {t('components.environmentEditor.preferredRuntimeNotes')}
-          </span>
-          <textarea
+        <FormField label={t('components.environmentEditor.preferredRuntimeNotes')}>
+          <Textarea
             value={values.preferred_runtime_notes}
             onChange={(event) => updateField('preferred_runtime_notes', event.target.value)}
             rows={3}
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
             placeholder={placeholders.preferredRuntimeNotes}
           />
-        </label>
+        </FormField>
 
-        <label className="space-y-2">
-          <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-            Task harness profile
-          </span>
-          <textarea
+        <FormField label="Task harness profile">
+          <Textarea
             value={values.task_harness_profile}
             onChange={(event) => updateField('task_harness_profile', event.target.value)}
             rows={5}
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
             placeholder={placeholders.taskHarnessProfile}
           />
-        </label>
+        </FormField>
 
-        <label className="space-y-2">
-          <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-            {t('components.environmentEditor.sshOptionsJson')}
-          </span>
-          <textarea
+        <FormField label={t('components.environmentEditor.sshOptionsJson')}>
+          <Textarea
             value={values.ssh_options}
             onChange={(event) => updateField('ssh_options', event.target.value)}
             rows={4}
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 font-mono text-sm tracking-[-0.12px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
+            className="font-mono text-sm tracking-[-0.12px]"
             placeholder={placeholders.sshOptionsJson}
           />
-        </label>
+        </FormField>
 
         {formError ? (
-          <p className="rounded-lg border border-[#ff3b30]/20 bg-[#ffebee] px-3 py-2 text-sm text-[#c62828]">
-            {formError}
-          </p>
+          <Alert variant="error">{formError}</Alert>
         ) : null}
 
         <div className="flex flex-wrap items-center gap-3">
-          <button
-            type="submit"
-            disabled={isSaving}
-            className="rounded-lg bg-[var(--apple-blue)] px-4 py-2 text-sm font-medium text-white transition hover:bg-[var(--apple-blue-hover)] disabled:cursor-not-allowed disabled:opacity-40"
-          >
+          <Button type="submit" disabled={isSaving}>
             {isSaving ? t('components.environmentEditor.saving') : submitLabel}
-          </button>
-          <button
-            type="button"
-            onClick={onCancel}
-            className="rounded-lg border border-[var(--border)] bg-[var(--bg)] px-4 py-2 text-sm font-medium text-[var(--text)] transition hover:bg-[var(--bg-secondary)]"
-          >
+          </Button>
+          <Button type="button" variant="secondary" onClick={onCancel}>
             {mode === 'create'
               ? t('components.environmentEditor.reset')
               : t('components.environmentEditor.cancelEdit')}
-          </button>
+          </Button>
         </div>
       </form>
-    </section>
+    </SectionCard>
   );
 }
 
@@ -437,37 +363,25 @@ function ProjectReferenceEditor({
 
   if (selectedEnvironment === null) {
     return (
-      <section className="space-y-4 rounded-xl bg-[var(--surface)] p-6 shadow-sm">
-        <div className="space-y-1">
-          <h2
-            className="text-xl font-semibold leading-tight tracking-[0.231px] text-[var(--text)]"
-            style={{ fontFamily: 'var(--font-display)' }}
-          >
-            {t('pages.containers.projectReferenceTitle')}
-          </h2>
-          <p className="text-sm leading-relaxed tracking-[-0.224px] text-[var(--text-secondary)]">
-            {t('pages.containers.projectReferenceDescription')}
-          </p>
-        </div>
+      <SectionCard>
+        <SectionHeader
+          title={t('pages.containers.projectReferenceTitle')}
+          description={t('pages.containers.projectReferenceDescription')}
+        />
         <p className="text-sm tracking-[-0.224px] text-[var(--text-tertiary)]">
           {t('pages.containers.projectReferenceNoSelection')}
         </p>
-      </section>
+      </SectionCard>
     );
   }
 
   return (
-    <section className="space-y-5 rounded-xl bg-[var(--surface)] p-6 shadow-sm">
+    <SectionCard>
       <div className="space-y-1">
-        <h2
-          className="text-xl font-semibold leading-tight tracking-[0.231px] text-[var(--text)]"
-          style={{ fontFamily: 'var(--font-display)' }}
-        >
-          {t('pages.containers.projectReferenceTitle')}
-        </h2>
-        <p className="text-sm leading-relaxed tracking-[-0.224px] text-[var(--text-secondary)]">
-          {t('pages.containers.projectReferenceDescription')}
-        </p>
+        <SectionHeader
+          title={t('pages.containers.projectReferenceTitle')}
+          description={t('pages.containers.projectReferenceDescription')}
+        />
         <p className="text-sm tracking-[-0.224px] text-[var(--text-secondary)]">
           <span className="font-medium text-[var(--text)]">{selectedEnvironment.alias}</span>
           <span className="ml-2 text-[var(--text-tertiary)]">({selectedEnvironment.display_name})</span>
@@ -476,24 +390,17 @@ function ProjectReferenceEditor({
 
       <div className="flex flex-wrap gap-2">
         {projectReference ? (
-          <span className="rounded-full bg-[var(--apple-blue)]/10 px-3 py-1 text-xs font-semibold text-[var(--apple-blue)]">
-            {t('pages.containers.projectReferencedBadge')}
-          </span>
+          <Badge>{t('pages.containers.projectReferencedBadge')}</Badge>
         ) : (
-          <span className="rounded-full bg-[var(--bg-secondary)] px-3 py-1 text-xs font-semibold text-[var(--text-tertiary)]">
-            {t('pages.containers.projectUnreferencedBadge')}
-          </span>
+          <Badge variant="secondary">{t('pages.containers.projectUnreferencedBadge')}</Badge>
         )}
         {projectReference?.is_default ? (
-          <span className="rounded-full bg-[var(--apple-blue)]/10 px-3 py-1 text-xs font-semibold text-[var(--apple-blue)]">
-            {t('pages.containers.projectDefaultBadge')}
-          </span>
+          <Badge>{t('pages.containers.projectDefaultBadge')}</Badge>
         ) : null}
       </div>
 
       <div className="flex flex-wrap gap-3">
-        <button
-          type="button"
+        <Button
           onClick={async () => {
             try {
               setFormError(null);
@@ -505,15 +412,14 @@ function ProjectReferenceEditor({
             }
           }}
           disabled={isSaving || isRemoving || projectReference?.is_default === true}
-          className="rounded-lg bg-[var(--apple-blue)] px-4 py-2 text-sm font-medium text-white transition hover:bg-[var(--apple-blue-hover)] disabled:cursor-not-allowed disabled:opacity-40"
         >
           {projectReference?.is_default
             ? t('pages.containers.setProjectDefaultDisabled')
             : t('pages.containers.setProjectDefault')}
-        </button>
+        </Button>
         {projectReference?.is_default ? (
-          <button
-            type="button"
+          <Button
+            variant="secondary"
             onClick={async () => {
               try {
                 setFormError(null);
@@ -525,14 +431,13 @@ function ProjectReferenceEditor({
               }
             }}
             disabled={isSaving || isRemoving}
-            className="rounded-lg border border-[var(--border)] bg-[var(--bg)] px-4 py-2 text-sm font-medium text-[var(--text)] transition hover:bg-[var(--bg-secondary)] disabled:cursor-not-allowed disabled:opacity-40"
           >
             {t('pages.containers.clearProjectDefault')}
-          </button>
+          </Button>
         ) : null}
         {projectReference ? (
-          <button
-            type="button"
+          <Button
+            variant="secondary"
             onClick={async () => {
               try {
                 setFormError(null);
@@ -544,10 +449,10 @@ function ProjectReferenceEditor({
               }
             }}
             disabled={isSaving || isRemoving}
-            className="rounded-lg border border-[#ff3b30]/20 bg-[#ffebee] px-4 py-2 text-sm font-medium text-[#c62828] transition hover:bg-[#ffcdd2] disabled:cursor-not-allowed disabled:opacity-40"
+            className="border-[#ff3b30]/20 bg-[#ffebee] text-[#c62828] hover:bg-[#ffcdd2] hover:text-[#c62828]"
           >
             {t('pages.containers.removeProjectReference')}
-          </button>
+          </Button>
         ) : null}
       </div>
 
@@ -565,76 +470,54 @@ function ProjectReferenceEditor({
           }
         }}
       >
-        <label className="space-y-2">
-          <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-            {t('pages.containers.projectOverrideWorkdir')}
-          </span>
-          <input
+        <FormField label={t('pages.containers.projectOverrideWorkdir')}>
+          <Input
             value={values.override_workdir}
             onChange={(event) => updateField('override_workdir', event.target.value)}
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
             placeholder={t('pages.containers.projectOverrideWorkdirPlaceholder')}
           />
-        </label>
+        </FormField>
 
         <div className="grid gap-4 sm:grid-cols-2">
-          <label className="space-y-2">
-            <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-              {t('pages.containers.projectOverrideEnvName')}
-            </span>
-            <input
+          <FormField label={t('pages.containers.projectOverrideEnvName')}>
+            <Input
               value={values.override_env_name}
               onChange={(event) => updateField('override_env_name', event.target.value)}
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
               placeholder={t('pages.containers.projectOverrideEnvNamePlaceholder')}
             />
-          </label>
+          </FormField>
 
-          <label className="space-y-2">
-            <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-              {t('pages.containers.projectOverrideEnvManager')}
-            </span>
-            <input
+          <FormField label={t('pages.containers.projectOverrideEnvManager')}>
+            <Input
               value={values.override_env_manager}
               onChange={(event) => updateField('override_env_manager', event.target.value)}
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
               placeholder={t('pages.containers.projectOverrideEnvManagerPlaceholder')}
             />
-          </label>
+          </FormField>
         </div>
 
-        <label className="space-y-2">
-          <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-            {t('pages.containers.projectOverrideRuntimeNotes')}
-          </span>
-          <textarea
+        <FormField label={t('pages.containers.projectOverrideRuntimeNotes')}>
+          <Textarea
             value={values.override_runtime_notes}
             onChange={(event) => updateField('override_runtime_notes', event.target.value)}
             rows={4}
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
             placeholder={t('pages.containers.projectOverrideRuntimeNotesPlaceholder')}
           />
-        </label>
+        </FormField>
 
         {formError ? (
-          <p className="rounded-lg border border-[#ff3b30]/20 bg-[#ffebee] px-3 py-2 text-sm text-[#c62828]">
-            {formError}
-          </p>
+          <Alert variant="error">{formError}</Alert>
         ) : null}
 
-        <button
-          type="submit"
-          disabled={isSaving || isRemoving}
-          className="rounded-lg bg-[var(--apple-blue)] px-4 py-2 text-sm font-medium text-white transition hover:bg-[var(--apple-blue-hover)] disabled:cursor-not-allowed disabled:opacity-40"
-        >
+        <Button type="submit" disabled={isSaving || isRemoving}>
           {isSaving
             ? t('pages.containers.projectReferenceSaving')
             : projectReference
               ? t('pages.containers.updateProjectReference')
               : t('pages.containers.attachProjectReference')}
-        </button>
+        </Button>
       </form>
-    </section>
+    </SectionCard>
   );
 }
 
@@ -824,22 +707,13 @@ function ContainersPage() {
 
   return (
     <div className="space-y-8">
-      <section className="space-y-3">
-        <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--apple-blue)]">
-          {t('pages.containers.eyebrow')}
-        </p>
-        <h1
-          className="text-[28px] font-normal leading-tight tracking-[0.196px] text-[var(--text)]"
-          style={{ fontFamily: 'var(--font-display)' }}
-        >
-          {t('pages.containers.title')}
-        </h1>
-        <p className="max-w-3xl text-base leading-relaxed tracking-[-0.374px] text-[var(--text-secondary)]">
-          {t('pages.containers.description')}
-        </p>
-      </section>
+      <PageHeader
+        eyebrow={t('pages.containers.eyebrow')}
+        title={t('pages.containers.title')}
+        description={t('pages.containers.description')}
+      />
 
-      <section className="flex flex-wrap items-center justify-between gap-3 rounded-xl bg-[var(--surface)] p-5 shadow-sm">
+      <SectionCard className="flex flex-wrap items-center justify-between gap-3 p-5">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--apple-blue)]">
             {t('pages.containers.currentSelection')}
@@ -848,28 +722,17 @@ function ContainersPage() {
             {activeEnvironmentSummary}
           </p>
         </div>
-        <button
-          type="button"
-          onClick={handleCreate}
-          className="rounded-lg bg-[var(--apple-blue)] px-4 py-2 text-sm font-medium text-white transition hover:bg-[var(--apple-blue-hover)]"
-        >
+        <Button onClick={handleCreate}>
           {t('pages.containers.addEnvironment')}
-        </button>
-      </section>
+        </Button>
+      </SectionCard>
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(0,1fr)]">
-        <section className="space-y-4 rounded-xl bg-[var(--surface)] p-6 shadow-sm">
-          <div className="space-y-1">
-            <h2
-              className="text-xl font-semibold leading-tight tracking-[0.231px] text-[var(--text)]"
-              style={{ fontFamily: 'var(--font-display)' }}
-            >
-              {t('pages.containers.listTitle')}
-            </h2>
-            <p className="text-sm leading-relaxed tracking-[-0.224px] text-[var(--text-secondary)]">
-              {t('pages.containers.listDescription')}
-            </p>
-          </div>
+        <SectionCard className="space-y-4">
+          <SectionHeader
+            title={t('pages.containers.listTitle')}
+            description={t('pages.containers.listDescription')}
+          />
 
           {environmentSelection.isLoading ? (
             <p className="text-sm tracking-[-0.224px] text-[var(--text-tertiary)]">
@@ -877,8 +740,8 @@ function ContainersPage() {
             </p>
           ) : null}
 
-          {requestError ? <p className="text-sm text-[#ff3b30]">{requestError}</p> : null}
-          {mutationError ? <p className="text-sm text-[#ff3b30]">{mutationError}</p> : null}
+          {requestError ? <Alert variant="error">{requestError}</Alert> : null}
+          {mutationError ? <Alert variant="error">{mutationError}</Alert> : null}
 
           {!environmentSelection.isLoading && environments.length === 0 ? (
             <div className="rounded-lg border border-dashed border-[var(--border)] bg-[var(--bg-secondary)] p-6 text-sm tracking-[-0.224px] text-[var(--text-tertiary)]">
@@ -927,24 +790,18 @@ function ContainersPage() {
                             <p className="font-medium text-[var(--text)]">
                               {environment.display_name}
                               {environment.is_seed ? (
-                                <span className="ml-2 rounded-full bg-[var(--apple-blue)]/10 px-2 py-0.5 text-xs font-semibold text-[var(--apple-blue)]">
-                                  {t('common.default')}
-                                </span>
+                                <Badge className="ml-2">{t('common.default')}</Badge>
                               ) : null}
                               {projectReference ? (
-                                <span className="ml-2 rounded-full bg-[var(--bg-secondary)] px-2 py-0.5 text-xs font-semibold text-[var(--text-tertiary)]">
+                                <Badge variant="secondary" className="ml-2">
                                   {t('pages.containers.projectReferencedBadge')}
-                                </span>
+                                </Badge>
                               ) : null}
                               {projectReference?.is_default ? (
-                                <span className="ml-2 rounded-full bg-[var(--apple-blue)]/10 px-2 py-0.5 text-xs font-semibold text-[var(--apple-blue)]">
-                                  {t('pages.containers.projectDefaultBadge')}
-                                </span>
+                                <Badge className="ml-2">{t('pages.containers.projectDefaultBadge')}</Badge>
                               ) : null}
                               {isActive ? (
-                                <span className="ml-2 rounded-full bg-[var(--apple-blue)]/10 px-2 py-0.5 text-xs font-semibold text-[var(--apple-blue)]">
-                                  {t('pages.containers.activeBadge')}
-                                </span>
+                                <Badge className="ml-2">{t('pages.containers.activeBadge')}</Badge>
                               ) : null}
                             </p>
                             <p className="text-xs tracking-[-0.12px] text-[var(--text-tertiary)]">
@@ -996,35 +853,37 @@ function ContainersPage() {
                         </td>
                         <td className="px-4 py-4">
                           <div className="flex flex-wrap gap-2">
-                            <button
-                              type="button"
+                            <Button
+                              variant="secondary"
+                              size="sm"
                               onClick={() => environmentSelection.onSelectEnvironment(environment.id)}
-                              className="rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-1.5 text-xs font-medium text-[var(--text)] transition hover:bg-[var(--bg-secondary)]"
                             >
                               {t('common.use')}
-                            </button>
-                            <button
-                              type="button"
+                            </Button>
+                            <Button
+                              variant="secondary"
+                              size="sm"
                               onClick={() => {
                                 setEditorMode('edit');
                                 setEditorEnvironmentId(environment.id);
                               }}
-                              className="rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-1.5 text-xs font-medium text-[var(--text)] transition hover:bg-[var(--bg-secondary)]"
                             >
                               {t('common.edit')}
-                            </button>
-                            <button
-                              type="button"
+                            </Button>
+                            <Button
+                              variant="secondary"
+                              size="sm"
                               onClick={() => {
                                 detectMutation.mutate(environment.id);
                               }}
                               disabled={detectMutation.isPending}
-                              className="rounded-lg border border-[var(--apple-blue)]/20 bg-[var(--apple-blue)]/10 px-3 py-1.5 text-xs font-medium text-[var(--apple-blue)] transition hover:bg-[var(--apple-blue)]/15 disabled:cursor-not-allowed disabled:opacity-50"
+                              className="border-[var(--apple-blue)]/20 bg-[var(--apple-blue)]/10 text-[var(--apple-blue)] hover:bg-[var(--apple-blue)]/15 hover:text-[var(--apple-blue)]"
                             >
                               {t('common.detect')}
-                            </button>
-                            <button
-                              type="button"
+                            </Button>
+                            <Button
+                              variant="secondary"
+                              size="sm"
                               onClick={() => {
                                 if (
                                   window.confirm(
@@ -1040,10 +899,10 @@ function ContainersPage() {
                                   ? t('pages.containers.defaultEnvironmentLocked')
                                   : undefined
                               }
-                              className="rounded-lg border border-[#ff3b30]/20 bg-[#ffebee] px-3 py-1.5 text-xs font-medium text-[#c62828] transition hover:bg-[#ffcdd2] disabled:cursor-not-allowed disabled:opacity-50"
+                              className="border-[#ff3b30]/20 bg-[#ffebee] text-[#c62828] hover:bg-[#ffcdd2] hover:text-[#c62828]"
                             >
                               {t('common.delete')}
-                            </button>
+                            </Button>
                           </div>
                         </td>
                       </tr>
@@ -1053,7 +912,7 @@ function ContainersPage() {
               </table>
             </div>
           ) : null}
-        </section>
+        </SectionCard>
 
         <div className="space-y-6">
           <EnvironmentEditor

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -3,6 +3,9 @@ import { getHealth } from '../api';
 import {
   EnvironmentSelectorPanel,
   HealthStatusBar,
+  PageHeader,
+  SectionCard,
+  SectionHeader,
   TerminalBenchCard,
   useEnvironmentSelection,
 } from '../components';
@@ -15,29 +18,15 @@ function DashboardPage() {
 
   return (
     <div className="space-y-8">
-      <section className="space-y-3">
-        <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--apple-blue)]">
-          {t('pages.dashboard.eyebrow')}
-        </p>
-        <h1
-          className="text-[28px] font-normal leading-tight tracking-[0.196px] text-[var(--text)]"
-          style={{ fontFamily: 'var(--font-display)' }}
-        >
-          {t('pages.dashboard.title')}
-        </h1>
-        <p className="max-w-3xl text-base leading-relaxed tracking-[-0.374px] text-[var(--text-secondary)]">
-          {t('pages.dashboard.description')}
-        </p>
-      </section>
+      <PageHeader
+        eyebrow={t('pages.dashboard.eyebrow')}
+        title={t('pages.dashboard.title')}
+        description={t('pages.dashboard.description')}
+      />
 
-      <section className="space-y-5 rounded-xl bg-[var(--surface)] p-6 shadow-sm">
+      <SectionCard>
         <div className="space-y-1">
-          <h2
-            className="text-lg font-semibold leading-tight tracking-[0.231px] text-[var(--text)]"
-            style={{ fontFamily: 'var(--font-display)' }}
-          >
-            {t('pages.dashboard.surfaceTitle')}
-          </h2>
+          <SectionHeader title={t('pages.dashboard.surfaceTitle')} />
           <p className="text-sm leading-relaxed tracking-[-0.224px] text-[var(--text-secondary)]">
             {t('pages.dashboard.endpointsLabel')}{' '}
             <code className="rounded bg-[var(--bg-tertiary)] px-1.5 py-0.5 text-xs">/health</code>,{' '}
@@ -70,7 +59,7 @@ function DashboardPage() {
         <HealthStatusBar health={healthQuery.data} isLoading={healthQuery.isLoading} />
         <EnvironmentSelectorPanel {...environmentSelection} />
         <TerminalBenchCard selectedEnvironment={environmentSelection.selectedEnvironment} />
-      </section>
+      </SectionCard>
     </div>
   );
 }

--- a/frontend/src/pages/FileBrowserPage.tsx
+++ b/frontend/src/pages/FileBrowserPage.tsx
@@ -3,7 +3,7 @@ import { useCallback, useState } from 'react';
 import { FolderOpen, RefreshCw } from 'lucide-react';
 import { listFiles, readFile } from '../api';
 import { FileTree, FileViewer } from '../components/file-browser';
-import { useEnvironmentSelection } from '../components';
+import { PageHeader, useEnvironmentSelection } from '../components';
 import { useT } from '../i18n';
 import type { FileEntry, FileReadResponse } from '../types';
 
@@ -67,17 +67,10 @@ export default function FileBrowserPage() {
 
   return (
     <div className="flex h-[calc(100vh-8rem)] flex-col gap-4">
-      <section className="space-y-3">
-        <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--apple-blue)]">
-          {t('pages.workspaceBrowser.eyebrow')}
-        </p>
-        <h1
-          className="text-[28px] font-normal leading-tight tracking-[0.196px] text-[var(--text)]"
-          style={{ fontFamily: 'var(--font-display)' }}
-        >
-          {t('pages.workspaceBrowser.title')}
-        </h1>
-      </section>
+      <PageHeader
+        eyebrow={t('pages.workspaceBrowser.eyebrow')}
+        title={t('pages.workspaceBrowser.title')}
+      />
 
       {!selectedEnvironment ? (
         <div className="flex flex-1 items-center justify-center rounded-xl border border-dashed border-[var(--border)] bg-[var(--bg-secondary)]">

--- a/frontend/src/pages/PlaceholderPage.tsx
+++ b/frontend/src/pages/PlaceholderPage.tsx
@@ -1,11 +1,11 @@
-interface PlaceholderPageProps {
+interface Props {
   eyebrow: string;
   title: string;
   description: string;
   badgeLabel: string;
 }
 
-function PlaceholderPage({ eyebrow, title, description, badgeLabel }: PlaceholderPageProps) {
+function PlaceholderPage({ eyebrow, title, description, badgeLabel }: Props) {
   return (
     <div className="px-4 py-8 sm:px-6 lg:px-8">
       <section className="rounded-2xl border border-dashed border-gray-300 bg-white/80 p-8 shadow-sm">

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,5 +1,16 @@
 import { useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  Alert,
+  Button,
+  FormField,
+  Input,
+  PageHeader,
+  SectionCard,
+  SectionHeader,
+  Select,
+  Textarea,
+} from '../components/ui';
 import { EnvironmentSelectorPanel, useEnvironmentSelection } from '../components';
 import TerminalSessionConsole from '../components/terminal/TerminalSessionConsole';
 import { getEnvironments, installEnvironmentCodeServer } from '../api';
@@ -102,25 +113,15 @@ function GeneralPreferencesSection({
     clampedFontSize !== savedGeneral.terminal.fontSize;
 
   return (
-    <section className="space-y-5 rounded-xl bg-[var(--surface)] p-6 shadow-sm">
-      <div className="space-y-1">
-        <h2
-          className="text-lg font-semibold leading-tight tracking-[0.231px] text-[var(--text)]"
-          style={{ fontFamily: 'var(--font-display)' }}
-        >
-          {t('pages.settings.general.title')}
-        </h2>
-        <p className="text-sm leading-relaxed tracking-[-0.224px] text-[var(--text-secondary)]">
-          {t('pages.settings.general.description')}
-        </p>
-      </div>
+    <SectionCard>
+      <SectionHeader
+        title={t('pages.settings.general.title')}
+        description={t('pages.settings.general.description')}
+      />
 
       <div className="grid gap-4 lg:grid-cols-2">
-        <label className="space-y-2">
-          <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-            {t('pages.settings.general.defaultRouteLabel')}
-          </span>
-          <select
+        <FormField label={t('pages.settings.general.defaultRouteLabel')}>
+          <Select
             aria-label={t('pages.settings.general.defaultRouteLabel')}
             value={draft.defaultRoute}
             onChange={(event) =>
@@ -129,20 +130,16 @@ function GeneralPreferencesSection({
                 defaultRoute: event.target.value as DefaultRoute,
               }))
             }
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
           >
             <option value="terminal">{t('pages.settings.routes.terminal')}</option>
             <option value="tasks">{t('pages.settings.routes.tasks')}</option>
             <option value="workspaces">{t('pages.settings.routes.workspaces')}</option>
             <option value="containers">{t('pages.settings.routes.containers')}</option>
-          </select>
-        </label>
+          </Select>
+        </FormField>
 
-        <label className="space-y-2">
-          <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-            {t('pages.settings.general.terminalFontSizeLabel')}
-          </span>
-          <input
+        <FormField label={t('pages.settings.general.terminalFontSizeLabel')}>
+          <Input
             aria-label={t('pages.settings.general.terminalFontSizeLabel')}
             type="number"
             min={minTerminalFontSize}
@@ -155,9 +152,8 @@ function GeneralPreferencesSection({
                 terminalFontSize: event.target.value,
               }))
             }
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
           />
-        </label>
+        </FormField>
       </div>
 
       <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg bg-[var(--bg-secondary)] px-4 py-3 text-sm tracking-[-0.224px] text-[var(--text-secondary)]">
@@ -169,15 +165,10 @@ function GeneralPreferencesSection({
           })}
         </p>
         <div className="flex flex-wrap gap-3">
-          <button
-            type="button"
-            onClick={onReset}
-            className="rounded-lg border border-[var(--border)] bg-[var(--bg)] px-4 py-2 text-sm font-medium text-[var(--text)] transition hover:bg-[var(--bg-secondary)]"
-          >
+          <Button variant="secondary" onClick={onReset}>
             {t('common.reset')}
-          </button>
-          <button
-            type="button"
+          </Button>
+          <Button
             onClick={() =>
               onSave({
                 defaultRoute: draft.defaultRoute,
@@ -187,13 +178,12 @@ function GeneralPreferencesSection({
               })
             }
             disabled={!hasChanges}
-            className="rounded-lg bg-[var(--apple-blue)] px-4 py-2 text-sm font-medium text-white transition hover:bg-[var(--apple-blue-hover)] disabled:cursor-not-allowed disabled:opacity-40"
           >
             {t('common.saveChanges')}
-          </button>
+          </Button>
         </div>
       </div>
-    </section>
+    </SectionCard>
   );
 }
 
@@ -209,29 +199,20 @@ function CodeServerInstallSection({
   const installedPath = environment?.code_server_path ?? null;
 
   return (
-    <section className="space-y-5 rounded-xl bg-[var(--surface)] p-6 shadow-sm">
+    <SectionCard>
       <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="space-y-1">
-          <h2
-            className="text-lg font-semibold leading-tight tracking-[0.231px] text-[var(--text)]"
-            style={{ fontFamily: 'var(--font-display)' }}
-          >
-            {t('pages.settings.codeServerInstall.title')}
-          </h2>
-          <p className="max-w-2xl text-sm leading-relaxed tracking-[-0.224px] text-[var(--text-secondary)]">
-            {t('pages.settings.codeServerInstall.description')}
-          </p>
-        </div>
-        <button
-          type="button"
+        <SectionHeader
+          title={t('pages.settings.codeServerInstall.title')}
+          description={t('pages.settings.codeServerInstall.description')}
+        />
+        <Button
           onClick={() => (environment ? onInstall(environment.id) : undefined)}
           disabled={!environment || isPending}
-          className="rounded-lg bg-[var(--apple-blue)] px-4 py-2 text-sm font-medium text-white transition hover:bg-[var(--apple-blue-hover)] disabled:cursor-not-allowed disabled:opacity-40"
         >
           {isPending
             ? t('pages.settings.codeServerInstall.installing')
             : t('pages.settings.codeServerInstall.installAction')}
-        </button>
+        </Button>
       </div>
 
       <div className="space-y-3 rounded-lg bg-[var(--bg-secondary)] p-4 text-sm tracking-[-0.224px]">
@@ -268,7 +249,7 @@ function CodeServerInstallSection({
           </div>
         </div>
       ) : null}
-    </section>
+    </SectionCard>
   );
 }
 
@@ -294,59 +275,41 @@ function TaskConfigurationSection({
   const [defaultConfigId, setDefaultConfigId] = useState(taskConfiguration.defaultTaskConfigurationId);
 
   return (
-    <section className="space-y-5 rounded-xl bg-[var(--surface)] p-6 shadow-sm">
-      <div className="space-y-1">
-        <h2
-          className="text-lg font-semibold leading-tight tracking-[0.231px] text-[var(--text)]"
-          style={{ fontFamily: 'var(--font-display)' }}
-        >
-          {t('pages.settings.taskConfiguration.title')}
-        </h2>
-        <p className="text-sm leading-relaxed tracking-[-0.224px] text-[var(--text-secondary)]">
-          {t('pages.settings.taskConfiguration.description')}
-        </p>
-      </div>
+    <SectionCard>
+      <SectionHeader
+        title={t('pages.settings.taskConfiguration.title')}
+        description={t('pages.settings.taskConfiguration.description')}
+      />
 
       <div className="grid gap-4 lg:grid-cols-2">
-        <label className="space-y-2">
-          <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-            {t('pages.settings.taskConfiguration.executionEngineLabel')}
-          </span>
-          <select
+        <FormField label={t('pages.settings.taskConfiguration.executionEngineLabel')}>
+          <Select
             aria-label={t('pages.settings.taskConfiguration.executionEngineLabel')}
             value={taskConfiguration.defaultExecutionEngineId}
             disabled
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg-tertiary)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)]"
           >
             <option value="claude-code">Claude Code</option>
-          </select>
-        </label>
+          </Select>
+        </FormField>
 
-        <label className="space-y-2">
-          <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-            {t('pages.settings.taskConfiguration.defaultTaskConfigurationLabel')}
-          </span>
-          <select
+        <FormField label={t('pages.settings.taskConfiguration.defaultTaskConfigurationLabel')}>
+          <Select
             aria-label={t('pages.settings.taskConfiguration.defaultTaskConfigurationLabel')}
             value={defaultConfigId}
             onChange={(event) => setDefaultConfigId(event.target.value)}
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
           >
             {taskConfiguration.taskConfigurations.map((config) => (
               <option key={config.configId} value={config.configId}>
                 {config.label}
               </option>
             ))}
-          </select>
-        </label>
+          </Select>
+        </FormField>
       </div>
 
       <div className="space-y-4 rounded-lg bg-[var(--bg-secondary)] p-4">
-        <label className="space-y-2">
-          <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-            {t('pages.settings.taskConfiguration.defaultResearchAgentLabel')}
-          </span>
-          <select
+        <FormField label={t('pages.settings.taskConfiguration.defaultResearchAgentLabel')}>
+          <Select
             aria-label={t('pages.settings.taskConfiguration.defaultResearchAgentLabel')}
             value={defaultProfileId}
             onChange={(event) => {
@@ -359,83 +322,64 @@ function TaskConfigurationSection({
                 setProfileDraft(nextProfile);
               }
             }}
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
           >
             {taskConfiguration.researchAgentProfiles.map((profile) => (
               <option key={profile.profileId} value={profile.profileId}>
                 {profile.label}
               </option>
             ))}
-          </select>
-        </label>
+          </Select>
+        </FormField>
 
-        <label className="block space-y-2">
-          <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-            {t('pages.settings.taskConfiguration.profileLabel')}
-          </span>
-          <input
+        <FormField label={t('pages.settings.taskConfiguration.profileLabel')}>
+          <Input
             aria-label={t('pages.settings.taskConfiguration.profileLabel')}
             value={profileDraft.label}
             onChange={(event) =>
               setProfileDraft((current) => ({ ...current, label: event.target.value }))
             }
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-4 py-3 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
           />
-        </label>
+        </FormField>
 
-        <label className="block space-y-2">
-          <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-            {t('pages.settings.taskConfiguration.systemPromptLabel')}
-          </span>
-          <textarea
+        <FormField label={t('pages.settings.taskConfiguration.systemPromptLabel')}>
+          <Textarea
             aria-label={t('pages.settings.taskConfiguration.systemPromptLabel')}
             value={profileDraft.systemPrompt}
             onChange={(event) =>
               setProfileDraft((current) => ({ ...current, systemPrompt: event.target.value }))
             }
-            className="min-h-24 w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-4 py-3 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
+            className="min-h-24"
           />
-        </label>
+        </FormField>
 
-        <label className="block space-y-2">
-          <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-            {t('pages.settings.taskConfiguration.skillsPromptLabel')}
-          </span>
-          <textarea
+        <FormField label={t('pages.settings.taskConfiguration.skillsPromptLabel')}>
+          <Textarea
             aria-label={t('pages.settings.taskConfiguration.skillsPromptLabel')}
             value={profileDraft.skillsPrompt}
             onChange={(event) =>
               setProfileDraft((current) => ({ ...current, skillsPrompt: event.target.value }))
             }
-            className="min-h-24 w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-4 py-3 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
+            className="min-h-24"
           />
-        </label>
+        </FormField>
 
-        <label className="block space-y-2">
-          <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-            {t('pages.settings.taskConfiguration.settingsJsonLabel')}
-          </span>
-          <textarea
+        <FormField label={t('pages.settings.taskConfiguration.settingsJsonLabel')}>
+          <Textarea
             aria-label={t('pages.settings.taskConfiguration.settingsJsonLabel')}
             value={profileDraft.settingsJson}
             onChange={(event) =>
               setProfileDraft((current) => ({ ...current, settingsJson: event.target.value }))
             }
-            className="min-h-28 w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-4 py-3 font-mono text-xs tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
+            className="min-h-28 font-mono text-xs"
           />
-        </label>
+        </FormField>
       </div>
 
       <div className="flex flex-wrap justify-end gap-3">
-        <button
-          type="button"
-          onClick={onResetTaskConfigurationSettings}
-          className="rounded-lg border border-[var(--border)] bg-[var(--bg)] px-4 py-2 text-sm font-medium text-[var(--text)] transition hover:bg-[var(--bg-secondary)]"
-        >
+        <Button variant="secondary" onClick={onResetTaskConfigurationSettings}>
           {t('common.reset')}
-        </button>
-        <button
-          type="button"
+        </Button>
+        <Button
           onClick={() => {
             onSaveResearchAgentProfile(profileDraft);
             onSaveTaskConfigurationSettings({
@@ -444,12 +388,11 @@ function TaskConfigurationSection({
               defaultTaskConfigurationId: defaultConfigId,
             });
           }}
-          className="rounded-lg bg-[var(--apple-blue)] px-4 py-2 text-sm font-medium text-white transition hover:bg-[var(--apple-blue-hover)]"
         >
           {t('common.saveChanges')}
-        </button>
+        </Button>
       </div>
-    </section>
+    </SectionCard>
   );
 }
 
@@ -465,24 +408,15 @@ function EnvironmentDefaultsCard({
   const hasChanges = hasEnvironmentDefaultChanges(draft, savedDefaults);
 
   return (
-    <section className="space-y-4 rounded-xl bg-[var(--surface)] p-5 shadow-sm">
-      <div className="space-y-1">
-        <h3
-          className="text-base font-semibold leading-tight tracking-[0.231px] text-[var(--text)]"
-          style={{ fontFamily: 'var(--font-display)' }}
-        >
-          {environment.alias} · {environment.display_name}
-        </h3>
-        <p className="text-sm leading-relaxed tracking-[-0.224px] text-[var(--text-secondary)]">
-          {t('pages.settings.project.environmentCardDescription')}
-        </p>
-      </div>
+    <SectionCard className="space-y-4 p-5">
+      <SectionHeader
+        title={`${environment.alias} · ${environment.display_name}`}
+        description={t('pages.settings.project.environmentCardDescription')}
+        size="sm"
+      />
 
-      <label className="block space-y-2">
-        <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-          {t('pages.settings.project.titleTemplateLabel')}
-        </span>
-        <input
+      <FormField label={t('pages.settings.project.titleTemplateLabel')}>
+        <Input
           aria-label={`${environment.alias} ${t('pages.settings.project.titleTemplateLabel')}`}
           value={draft.titleTemplate}
           onChange={(event) =>
@@ -491,16 +425,12 @@ function EnvironmentDefaultsCard({
               titleTemplate: event.target.value,
             }))
           }
-          className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-4 py-3 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
           placeholder={t('pages.settings.project.titleTemplatePlaceholder')}
         />
-      </label>
+      </FormField>
 
-      <label className="block space-y-2">
-        <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-          {t('pages.settings.project.taskInputTemplateLabel')}
-        </span>
-        <textarea
+      <FormField label={t('pages.settings.project.taskInputTemplateLabel')}>
+        <Textarea
           aria-label={`${environment.alias} ${t('pages.settings.project.taskInputTemplateLabel')}`}
           value={draft.taskInputTemplate}
           onChange={(event) =>
@@ -509,16 +439,13 @@ function EnvironmentDefaultsCard({
               taskInputTemplate: event.target.value,
             }))
           }
-          className="min-h-32 w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-4 py-3 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
+          className="min-h-32"
           placeholder={t('pages.settings.project.taskInputTemplatePlaceholder')}
         />
-      </label>
+      </FormField>
 
-      <label className="block space-y-2">
-        <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-          {t('pages.settings.project.researchAgentDefaultLabel')}
-        </span>
-        <select
+      <FormField label={t('pages.settings.project.researchAgentDefaultLabel')}>
+        <Select
           aria-label={`${environment.alias} ${t('pages.settings.project.researchAgentDefaultLabel')}`}
           value={draft.researchAgentProfileId}
           onChange={(event) =>
@@ -527,21 +454,17 @@ function EnvironmentDefaultsCard({
               researchAgentProfileId: event.target.value,
             }))
           }
-          className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
         >
           {taskConfiguration.researchAgentProfiles.map((profile) => (
             <option key={profile.profileId} value={profile.profileId}>
               {profile.label}
             </option>
           ))}
-        </select>
-      </label>
+        </Select>
+      </FormField>
 
-      <label className="block space-y-2">
-        <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-          {t('pages.settings.project.taskConfigurationDefaultLabel')}
-        </span>
-        <select
+      <FormField label={t('pages.settings.project.taskConfigurationDefaultLabel')}>
+        <Select
           aria-label={`${environment.alias} ${t('pages.settings.project.taskConfigurationDefaultLabel')}`}
           value={draft.taskConfigurationId}
           onChange={(event) =>
@@ -550,34 +473,24 @@ function EnvironmentDefaultsCard({
               taskConfigurationId: event.target.value,
             }))
           }
-          className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
         >
           {taskConfiguration.taskConfigurations.map((config) => (
             <option key={config.configId} value={config.configId}>
               {config.label}
             </option>
           ))}
-        </select>
-      </label>
+        </Select>
+      </FormField>
 
       <div className="flex flex-wrap justify-end gap-3">
-        <button
-          type="button"
-          onClick={onReset}
-          className="rounded-lg border border-[var(--border)] bg-[var(--bg)] px-4 py-2 text-sm font-medium text-[var(--text)] transition hover:bg-[var(--bg-secondary)]"
-        >
+        <Button variant="secondary" onClick={onReset}>
           {t('common.reset')}
-        </button>
-        <button
-          type="button"
-          onClick={() => onSave(draft)}
-          disabled={!hasChanges}
-          className="rounded-lg bg-[var(--apple-blue)] px-4 py-2 text-sm font-medium text-white transition hover:bg-[var(--apple-blue-hover)] disabled:cursor-not-allowed disabled:opacity-40"
-        >
+        </Button>
+        <Button onClick={() => onSave(draft)} disabled={!hasChanges}>
           {t('common.saveChanges')}
-        </button>
+        </Button>
       </div>
-    </section>
+    </SectionCard>
   );
 }
 
@@ -600,30 +513,19 @@ function ProjectDefaultsSection({
   const hasProjectDefaultChanges = defaultEnvironmentDraft !== persistedProjectDefaultEnvironmentId;
 
   return (
-    <section className="space-y-5 rounded-xl bg-[var(--surface)] p-6 shadow-sm">
-      <div className="space-y-1">
-        <h2
-          className="text-lg font-semibold leading-tight tracking-[0.231px] text-[var(--text)]"
-          style={{ fontFamily: 'var(--font-display)' }}
-        >
-          {t('pages.settings.project.title')}
-        </h2>
-        <p className="text-sm leading-relaxed tracking-[-0.224px] text-[var(--text-secondary)]">
-          {t('pages.settings.project.description')}
-        </p>
-      </div>
+    <SectionCard>
+      <SectionHeader
+        title={t('pages.settings.project.title')}
+        description={t('pages.settings.project.description')}
+      />
 
       <div className="space-y-4 rounded-lg bg-[var(--bg-secondary)] p-4">
-        <label className="space-y-2">
-          <span className="text-sm font-medium tracking-[-0.224px] text-[var(--text)]">
-            {t('pages.settings.project.defaultEnvironmentLabel')}
-          </span>
-          <select
+        <FormField label={t('pages.settings.project.defaultEnvironmentLabel')}>
+          <Select
             aria-label={t('pages.settings.project.defaultEnvironmentLabel')}
             value={defaultEnvironmentDraft}
             onChange={(event) => setDefaultEnvironmentDraft(event.target.value)}
             disabled={environments.length === 0}
-            className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-3 py-2.5 text-sm tracking-[-0.224px] text-[var(--text)] outline-none transition focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15 disabled:cursor-not-allowed disabled:bg-[var(--bg-tertiary)] disabled:text-[var(--text-tertiary)]"
           >
             <option value="">{t('pages.settings.project.defaultEnvironmentEmpty')}</option>
             {environments.map((environment) => (
@@ -631,29 +533,23 @@ function ProjectDefaultsSection({
                 {environment.alias} · {environment.display_name}
               </option>
             ))}
-          </select>
-        </label>
+          </Select>
+        </FormField>
 
         <div className="flex flex-wrap items-center justify-between gap-3">
           <p className="text-sm tracking-[-0.224px] text-[var(--text-secondary)]">
             {t('pages.settings.project.defaultEnvironmentHelp')}
           </p>
           <div className="flex flex-wrap gap-3">
-            <button
-              type="button"
-              onClick={() => saveProjectDefaultEnvironment(null)}
-              className="rounded-lg border border-[var(--border)] bg-[var(--bg)] px-4 py-2 text-sm font-medium text-[var(--text)] transition hover:bg-[var(--bg-secondary)]"
-            >
+            <Button variant="secondary" onClick={() => saveProjectDefaultEnvironment(null)}>
               {t('common.reset')}
-            </button>
-            <button
-              type="button"
+            </Button>
+            <Button
               onClick={() => saveProjectDefaultEnvironment(defaultEnvironmentDraft || null)}
               disabled={!hasProjectDefaultChanges}
-              className="rounded-lg bg-[var(--apple-blue)] px-4 py-2 text-sm font-medium text-white transition hover:bg-[var(--apple-blue-hover)] disabled:cursor-not-allowed disabled:opacity-40"
             >
               {t('common.saveChanges')}
-            </button>
+            </Button>
           </div>
         </div>
       </div>
@@ -685,7 +581,7 @@ function ProjectDefaultsSection({
           );
         })}
       </div>
-    </section>
+    </SectionCard>
   );
 }
 
@@ -773,26 +669,15 @@ function SettingsPage() {
 
   return (
     <div className="space-y-8">
-      <section className="space-y-3">
-        <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--apple-blue)]">
-          {t('pages.settings.eyebrow')}
-        </p>
-        <h1
-          className="text-[28px] font-normal leading-tight tracking-[0.196px] text-[var(--text)]"
-          style={{ fontFamily: 'var(--font-display)' }}
-        >
-          {t('pages.settings.title')}
-        </h1>
-        <p className="max-w-3xl text-base leading-relaxed tracking-[-0.374px] text-[var(--text-secondary)]">
-          {t('pages.settings.description')}
-        </p>
-      </section>
+      <PageHeader
+        eyebrow={t('pages.settings.eyebrow')}
+        title={t('pages.settings.title')}
+        description={t('pages.settings.description')}
+      />
 
       <div className="space-y-6">
         {recoveryReason !== null ? (
-          <section className="rounded-lg border border-[#ffb74d]/30 bg-[#fff8e1] px-4 py-3 text-sm tracking-[-0.224px] text-[#e65100]">
-            {t('pages.settings.recoveryNotice')}
-          </section>
+          <Alert variant="warning">{t('pages.settings.recoveryNotice')}</Alert>
         ) : null}
 
         <GeneralPreferencesSection

--- a/frontend/src/pages/TasksPage.tsx
+++ b/frontend/src/pages/TasksPage.tsx
@@ -3,9 +3,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useSearchParams } from 'react-router-dom';
 import { createTask, getTask, getTasks, getWorkspaces } from '../api';
+import { Button } from '../components/ui';
 import { useEnvironmentSelection } from '../components';
 import { useT } from '../i18n';
 import { createEmptyEnvironmentTaskDefaults, useSettings } from '../settings';
+import { extractErrorMessage } from '../utils/error';
 import type { TaskCreateRequest, TaskSummary } from '../types';
 import TaskCreateForm from './tasks/TaskCreateForm';
 import TaskDetail from './tasks/TaskDetail';
@@ -117,9 +119,9 @@ function TasksPage() {
     };
   }, [environmentSelection.selectedEnvironmentId, settings.projectDefaults.default.environmentDefaults]);
 
-  const createError = createMutation.error instanceof Error ? createMutation.error.message : null;
-  const tasksError = tasksQuery.error instanceof Error ? tasksQuery.error.message : null;
-  const detailError = selectedTaskQuery.error instanceof Error ? selectedTaskQuery.error.message : null;
+  const createError = extractErrorMessage(createMutation.error);
+  const tasksError = extractErrorMessage(tasksQuery.error);
+  const detailError = extractErrorMessage(selectedTaskQuery.error);
 
   const closeCreateDialog = useCallback(() => {
     setCreateDialogOpen(false);
@@ -183,8 +185,8 @@ function TasksPage() {
   }, []);
 
   return (
-    <div className="flex min-h-0 flex-1 bg-[var(--background)] p-4">
-      <div className="flex min-h-0 w-full overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-[var(--shadow-pane)]">
+    <div className="flex min-h-0 flex-1 bg-[var(--bg)] p-4">
+      <div className="flex min-h-0 w-full overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--surface)] shadow-sm">
         <aside
           data-testid="task-sidebar"
           className="flex shrink-0 flex-col bg-[var(--sidebar)] p-3"
@@ -192,25 +194,24 @@ function TasksPage() {
         >
           <div className="mb-3 flex items-start justify-between gap-3 border-b border-[var(--sidebar-border)] pb-3">
             <div className="min-w-0">
-              <p className="text-xs font-medium uppercase tracking-wide text-[var(--muted-foreground)]">
+              <p className="text-xs font-medium uppercase tracking-wide text-[var(--text-secondary)]">
                 {t('pages.tasks.sidebarEyebrow')}
               </p>
               <h1 className="mt-1 truncate text-lg font-semibold tracking-tight text-[var(--sidebar-foreground)]">
                 {t('pages.tasks.sidebarTitle')}
               </h1>
-              <p className="mt-1 text-xs text-[var(--muted-foreground)]">
+              <p className="mt-1 text-xs text-[var(--text-secondary)]">
                 {t('pages.tasks.sidebarCount', { count: tasks.length })}
               </p>
             </div>
-            <button
+            <Button
               ref={createButtonRef}
-              type="button"
               onClick={() => setCreateDialogOpen(true)}
-              className="inline-flex h-9 items-center gap-2 rounded-lg bg-[var(--primary)] px-3 text-sm font-medium text-[var(--primary-foreground)] shadow-[var(--shadow-toolbar)] transition hover:opacity-90"
+              className="inline-flex h-9 items-center gap-2 px-3 shadow-sm"
             >
               <Plus size={15} />
               {t('pages.tasks.newTask')}
-            </button>
+            </Button>
           </div>
 
           <TaskList
@@ -233,12 +234,12 @@ function TasksPage() {
           tabIndex={0}
           onPointerDown={handleSplitterPointerDown}
           onKeyDown={handleSplitterKeyDown}
-          className="group flex w-2 shrink-0 cursor-col-resize items-stretch justify-center bg-[var(--card)] outline-none transition hover:bg-[var(--muted)] focus:bg-[var(--muted)]"
+          className="group flex w-2 shrink-0 cursor-col-resize items-stretch justify-center bg-[var(--surface)] outline-none transition hover:bg-[var(--bg-secondary)] focus:bg-[var(--bg-secondary)]"
         >
-          <span className="my-3 w-px rounded-full bg-[var(--border)] transition group-hover:bg-[var(--accent)] group-focus:bg-[var(--accent)]" />
+          <span className="my-3 w-px rounded-full bg-[var(--border)] transition group-hover:bg-[var(--apple-blue)] group-focus:bg-[var(--apple-blue)]" />
         </div>
 
-        <main className="flex min-w-0 flex-1 flex-col bg-[var(--background)] p-4">
+        <main className="flex min-w-0 flex-1 flex-col bg-[var(--bg)] p-4">
           <TaskDetail
             selectedTask={selectedTask}
             detailError={detailError}
@@ -261,7 +262,7 @@ function TasksPage() {
                 closeCreateDialog();
               }
             }}
-            className="max-h-[90vh] w-full max-w-2xl overflow-auto rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5 shadow-2xl"
+            className="max-h-[90vh] w-full max-w-2xl overflow-auto rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-5 shadow-2xl"
           >
             <TaskCreateForm
               key={`${effectiveEnvironmentId}:${draftResetVersion}`}

--- a/frontend/src/pages/TerminalPage.test.tsx
+++ b/frontend/src/pages/TerminalPage.test.tsx
@@ -33,6 +33,12 @@ const selectedEnvironment: EnvironmentRecord = {
 vi.mock('../components', () => ({
   EnvironmentSelectorPanel: () => <div data-testid="environment-selector" />,
   TerminalBenchCard: () => <div data-testid="terminal-bench-card" />,
+  PageHeader: ({ eyebrow, title }: { eyebrow: string; title: string }) => (
+    <div>
+      <p>{eyebrow}</p>
+      <h1>{title}</h1>
+    </div>
+  ),
   useEnvironmentSelection: () => ({
     selectedEnvironment,
     selectedEnvironmentId: selectedEnvironment.id,

--- a/frontend/src/pages/TerminalPage.tsx
+++ b/frontend/src/pages/TerminalPage.tsx
@@ -1,29 +1,17 @@
-import { TerminalBenchCard, useEnvironmentSelection } from '../components';
+import { PageHeader, TerminalBenchCard, useEnvironmentSelection } from '../components';
 import { useT } from '../i18n';
 
 function TerminalPage() {
   const t = useT();
   const environmentSelection = useEnvironmentSelection();
-  const description = t('pages.terminal.description');
 
   return (
     <div className="space-y-8">
-      <section className="space-y-3">
-        <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--apple-blue)]">
-          {t('pages.terminal.eyebrow')}
-        </p>
-        <h1
-          className="text-[28px] font-normal leading-tight tracking-[0.196px] text-[var(--text)]"
-          style={{ fontFamily: 'var(--font-display)' }}
-        >
-          {t('pages.terminal.title')}
-        </h1>
-        {description ? (
-          <p className="max-w-3xl text-base leading-relaxed tracking-[-0.374px] text-[var(--text-secondary)]">
-            {description}
-          </p>
-        ) : null}
-      </section>
+      <PageHeader
+        eyebrow={t('pages.terminal.eyebrow')}
+        title={t('pages.terminal.title')}
+        description={t('pages.terminal.description')}
+      />
 
       <TerminalBenchCard selectedEnvironment={environmentSelection.selectedEnvironment} />
     </div>

--- a/frontend/src/pages/WorkspacesPage.test.tsx
+++ b/frontend/src/pages/WorkspacesPage.test.tsx
@@ -20,6 +20,12 @@ vi.mock('../api', () => ({
 vi.mock('../components', () => ({
   CodeServerCard: () => <div data-testid="code-server-card" />,
   EnvironmentSelectorPanel: () => <div data-testid="environment-selector" />,
+  PageHeader: ({ eyebrow, title }: { eyebrow: string; title: string }) => (
+    <div>
+      <p>{eyebrow}</p>
+      <h1>{title}</h1>
+    </div>
+  ),
   useEnvironmentSelection: () => ({
     selectedEnvironment: null,
     selectedEnvironmentId: null,

--- a/frontend/src/pages/WorkspacesPage.tsx
+++ b/frontend/src/pages/WorkspacesPage.tsx
@@ -1,3 +1,4 @@
+import { PageHeader } from '../components';
 import { useT } from '../i18n';
 import WorkspaceManagerCard from './workspaces/WorkspaceManagerCard';
 
@@ -6,20 +7,11 @@ function WorkspacesPage() {
 
   return (
     <div className="space-y-8">
-      <section className="space-y-3">
-        <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--apple-blue)]">
-          {t('pages.workspaces.eyebrow')}
-        </p>
-        <h1
-          className="text-[28px] font-normal leading-tight tracking-[0.196px] text-[var(--text)]"
-          style={{ fontFamily: 'var(--font-display)' }}
-        >
-          {t('pages.workspaces.title')}
-        </h1>
-        <p className="max-w-3xl text-base leading-relaxed tracking-[-0.374px] text-[var(--text-secondary)]">
-          {t('pages.workspaces.description')}
-        </p>
-      </section>
+      <PageHeader
+        eyebrow={t('pages.workspaces.eyebrow')}
+        title={t('pages.workspaces.title')}
+        description={t('pages.workspaces.description')}
+      />
 
       <WorkspaceManagerCard />
     </div>

--- a/frontend/src/pages/tasks/TaskCreateForm.tsx
+++ b/frontend/src/pages/tasks/TaskCreateForm.tsx
@@ -1,5 +1,6 @@
 import { X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
+import { Button, Input, Select, Textarea } from '../../components/ui';
 import { useT } from '../../i18n';
 import type {
   EnvironmentRecord,
@@ -8,7 +9,7 @@ import type {
 } from '../../types';
 import type { ResearchAgentProfileSettings, TaskConfigurationPreset } from '../../settings';
 
-interface TaskCreateFormProps {
+interface Props {
   workspaces: WorkspaceRecord[];
   environments: EnvironmentRecord[];
   selectedWorkspaceId: string;
@@ -47,7 +48,7 @@ export default function TaskCreateForm({
   onSelectEnvironment,
   onSubmit,
   onClose,
-}: TaskCreateFormProps) {
+}: Props) {
   const t = useT();
   const [draft, setDraft] = useState({
     title: draftDefaults.title,
@@ -144,136 +145,131 @@ export default function TaskCreateForm({
     >
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h2 className="text-base font-semibold tracking-tight text-[var(--foreground)]">
+          <h2 className="text-base font-semibold tracking-tight text-[var(--text)]">
             {t('pages.tasks.createTitle')}
           </h2>
-          <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+          <p className="mt-1 text-sm text-[var(--text-secondary)]">
             {t('pages.tasks.createDescription')}
           </p>
         </div>
         {onClose ? (
-          <button
+          <Button
             type="button"
+            variant="ghost"
             onClick={onClose}
-            className="inline-flex h-8 w-8 items-center justify-center rounded-md text-[var(--muted-foreground)] transition hover:bg-[var(--muted)] hover:text-[var(--foreground)]"
+            className="h-8 w-8 p-0 inline-flex items-center justify-center rounded-md"
             aria-label={t('pages.tasks.closeCreate')}
           >
             <X size={16} />
-          </button>
+          </Button>
         ) : null}
       </div>
 
       <div className="grid gap-3 sm:grid-cols-2">
         <label className="block space-y-2">
-          <span className="text-xs font-medium text-[var(--muted-foreground)]">
+          <span className="text-xs font-medium text-[var(--text-secondary)]">
             {t('pages.tasks.workspaceLabel')}
           </span>
-          <select
+          <Select
             aria-label={t('pages.tasks.workspaceLabel')}
             value={selectedWorkspaceId}
             onChange={(event) => onSelectWorkspace(event.target.value)}
-            className="h-10 w-full rounded-lg border border-[var(--input)] bg-[var(--background)] px-3 text-sm text-[var(--foreground)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--ring)]"
           >
             {workspaces.map((workspace) => (
               <option key={workspace.workspace_id} value={workspace.workspace_id}>
                 {workspace.label}
               </option>
             ))}
-          </select>
+          </Select>
         </label>
 
         <label className="block space-y-2">
-          <span className="text-xs font-medium text-[var(--muted-foreground)]">
+          <span className="text-xs font-medium text-[var(--text-secondary)]">
             {t('pages.tasks.environmentLabel')}
           </span>
-          <select
+          <Select
             aria-label={t('pages.tasks.environmentLabel')}
             value={selectedEnvironmentId}
             onChange={(event) => onSelectEnvironment(event.target.value)}
-            className="h-10 w-full rounded-lg border border-[var(--input)] bg-[var(--background)] px-3 text-sm text-[var(--foreground)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--ring)]"
           >
             {environments.map((environment) => (
               <option key={environment.id} value={environment.id}>
                 {environment.alias} · {environment.display_name}
               </option>
             ))}
-          </select>
+          </Select>
         </label>
       </div>
 
       <label className="block space-y-2">
-        <span className="text-xs font-medium text-[var(--muted-foreground)]">
+        <span className="text-xs font-medium text-[var(--text-secondary)]">
           {t('pages.tasks.profileLabel')}
         </span>
-        <select
+        <Select
           aria-label={t('pages.tasks.profileLabel')}
           value={draft.task_profile}
           onChange={(event) =>
             setDraft((current) => ({ ...current, task_profile: event.target.value }))
           }
-          className="h-10 w-full rounded-lg border border-[var(--input)] bg-[var(--background)] px-3 text-sm text-[var(--foreground)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--ring)]"
         >
           <option value="claude-code">claude-code</option>
-        </select>
+        </Select>
       </label>
 
       <div className="grid gap-3 sm:grid-cols-2">
         <label className="block space-y-2">
-          <span className="text-xs font-medium text-[var(--muted-foreground)]">
+          <span className="text-xs font-medium text-[var(--text-secondary)]">
             {t('pages.tasks.researchAgentLabel')}
           </span>
-          <select
+          <Select
             aria-label={t('pages.tasks.researchAgentLabel')}
             value={draft.researchAgentProfileId}
             onChange={(event) =>
               setDraft((current) => ({ ...current, researchAgentProfileId: event.target.value }))
             }
-            className="h-10 w-full rounded-lg border border-[var(--input)] bg-[var(--background)] px-3 text-sm text-[var(--foreground)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--ring)]"
           >
             {researchAgentProfiles.map((profile) => (
               <option key={profile.profileId} value={profile.profileId}>
                 {profile.label}
               </option>
             ))}
-          </select>
+          </Select>
         </label>
 
         <label className="block space-y-2">
-          <span className="text-xs font-medium text-[var(--muted-foreground)]">
+          <span className="text-xs font-medium text-[var(--text-secondary)]">
             {t('pages.tasks.taskConfigurationLabel')}
           </span>
-          <select
+          <Select
             aria-label={t('pages.tasks.taskConfigurationLabel')}
             value={draft.taskConfigurationId}
             onChange={(event) =>
               setDraft((current) => ({ ...current, taskConfigurationId: event.target.value }))
             }
-            className="h-10 w-full rounded-lg border border-[var(--input)] bg-[var(--background)] px-3 text-sm text-[var(--foreground)] outline-none transition focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--ring)]"
           >
             {taskConfigurations.map((configuration) => (
               <option key={configuration.configId} value={configuration.configId}>
                 {configuration.label}
               </option>
             ))}
-          </select>
+          </Select>
         </label>
       </div>
 
       <label className="block space-y-2">
-        <span className="text-xs font-medium text-[var(--muted-foreground)]">
+        <span className="text-xs font-medium text-[var(--text-secondary)]">
           {t('pages.tasks.titleLabel')}
         </span>
-        <input
+        <Input
           aria-label={t('pages.tasks.titleLabel')}
           value={draft.title}
           onChange={(event) => setDraft((current) => ({ ...current, title: event.target.value }))}
-          className="h-10 w-full rounded-lg border border-[var(--input)] bg-[var(--background)] px-3 text-sm text-[var(--foreground)] outline-none transition placeholder:text-[var(--muted-foreground)] focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--ring)]"
           placeholder={t('pages.tasks.optionalPlaceholder')}
         />
       </label>
 
       {selectedTaskConfiguration?.mode === 'structured_research' ? (
-        <div className="space-y-3 rounded-lg border border-[var(--border)] bg-[var(--muted)]/40 p-3">
+        <div className="space-y-3 rounded-lg border border-[var(--border)] bg-[var(--bg-secondary)]/40 p-3">
           {[
             ['researchGoal', 'structuredResearchGoal'],
             ['context', 'structuredResearchContext'],
@@ -282,21 +278,21 @@ export default function TaskCreateForm({
             ['validationPlan', 'structuredResearchValidationPlan'],
           ].map(([field, labelKey]) => (
             <label key={field} className="block space-y-2">
-              <span className="text-xs font-medium text-[var(--muted-foreground)]">
+              <span className="text-xs font-medium text-[var(--text-secondary)]">
                 {t(`pages.tasks.${labelKey}` as Parameters<typeof t>[0])}
               </span>
-              <textarea
+              <Textarea
                 aria-label={t(`pages.tasks.${labelKey}` as Parameters<typeof t>[0])}
                 value={String(draft[field as keyof typeof draft])}
                 onChange={(event) =>
                   setDraft((current) => ({ ...current, [field]: event.target.value }))
                 }
-                className="min-h-20 w-full rounded-lg border border-[var(--input)] bg-[var(--background)] px-3 py-3 text-sm text-[var(--foreground)] outline-none transition placeholder:text-[var(--muted-foreground)] focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--ring)]"
+                className="min-h-20"
               />
             </label>
           ))}
-          <div className="rounded-lg bg-[var(--background)] p-3 text-xs text-[var(--muted-foreground)]">
-            <p className="mb-2 font-medium text-[var(--foreground)]">
+          <div className="rounded-lg bg-[var(--bg)] p-3 text-xs text-[var(--text-secondary)]">
+            <p className="mb-2 font-medium text-[var(--text)]">
               {t('pages.tasks.generatedPromptPreview')}
             </p>
             <pre className="whitespace-pre-wrap font-mono">{structuredPrompt}</pre>
@@ -304,36 +300,36 @@ export default function TaskCreateForm({
         </div>
       ) : (
         <label className="block space-y-2">
-          <span className="text-xs font-medium text-[var(--muted-foreground)]">
+          <span className="text-xs font-medium text-[var(--text-secondary)]">
             {t('pages.tasks.taskInputLabel')}
           </span>
-          <textarea
+          <Textarea
             ref={taskInputRef}
             aria-label={t('pages.tasks.taskInputLabel')}
             value={draft.task_input}
             onChange={(event) =>
               setDraft((current) => ({ ...current, task_input: event.target.value }))
             }
-            className="min-h-44 w-full rounded-lg border border-[var(--input)] bg-[var(--background)] px-3 py-3 text-sm text-[var(--foreground)] outline-none transition placeholder:text-[var(--muted-foreground)] focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--ring)]"
+            className="min-h-44"
             placeholder={t('pages.tasks.taskInputPlaceholder')}
           />
         </label>
       )}
 
       {selectedWorkspace ? (
-        <p className="rounded-lg bg-[var(--muted)] px-3 py-2 text-xs text-[var(--muted-foreground)]">
+        <p className="rounded-lg bg-[var(--bg-secondary)] px-3 py-2 text-xs text-[var(--text-secondary)]">
           {t('pages.tasks.defaultWorkdir')}{' '}
-          <code className="rounded bg-[var(--code-background)] px-1.5 py-0.5 text-[var(--code-foreground)]">
+          <code className="rounded bg-[var(--bg-tertiary)] px-1.5 py-0.5 text-[var(--text)]">
             {selectedWorkspace.default_workdir ?? t('pages.tasks.unavailable')}
           </code>
         </p>
       ) : null}
-      {createError ? <p className="text-sm text-[var(--destructive)]">{createError}</p> : null}
+      {createError ? <p className="text-sm text-[#ff3b30]">{createError}</p> : null}
 
       <div className="flex flex-wrap items-center justify-end gap-3 border-t border-[var(--border)] pt-4">
-        <button
+        <Button
           type="button"
-          className="rounded-lg border border-[var(--border)] bg-[var(--background)] px-4 py-2 text-sm font-medium text-[var(--foreground)] transition hover:bg-[var(--muted)]"
+          variant="secondary"
           onClick={() =>
             setDraft({
               title: draftDefaults.title,
@@ -350,15 +346,11 @@ export default function TaskCreateForm({
           }
         >
           {t('pages.tasks.resetDraft')}
-        </button>
+        </Button>
 
-        <button
-          type="submit"
-          disabled={!canCreate}
-          className="rounded-lg bg-[var(--primary)] px-4 py-2 text-sm font-medium text-[var(--primary-foreground)] transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
-        >
+        <Button type="submit" disabled={!canCreate}>
           {isSubmitting ? t('pages.tasks.creatingAction') : t('pages.tasks.createAction')}
-        </button>
+        </Button>
       </div>
     </form>
   );

--- a/frontend/src/pages/tasks/TaskDetail.tsx
+++ b/frontend/src/pages/tasks/TaskDetail.tsx
@@ -1,15 +1,9 @@
+import { Alert } from '../../components/ui';
 import { useT } from '../../i18n';
-import type { TaskOutputEvent, TaskRecord, TaskStatus } from '../../types';
+import type { TaskOutputEvent, TaskRecord } from '../../types';
+import { statusClassName } from './status';
 
-const statusClassName: Record<TaskStatus, string> = {
-  queued: 'border-[var(--border)] bg-[var(--muted)] text-[var(--muted-foreground)]',
-  starting: 'border-blue-500/20 bg-blue-500/10 text-blue-600',
-  running: 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600',
-  succeeded: 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600',
-  failed: 'border-red-500/20 bg-red-500/10 text-red-600',
-};
-
-interface TaskDetailProps {
+interface Props {
   selectedTask: TaskRecord | null;
   detailError: string | null;
   outputItems: TaskOutputEvent[];
@@ -27,8 +21,8 @@ function MetadataRow({
 }) {
   return (
     <div className="flex items-start justify-between gap-4 border-b border-[var(--border)] py-2 last:border-0">
-      <span className="text-xs text-[var(--muted-foreground)]">{label}</span>
-      <span className="max-w-[70%] text-right text-xs font-medium text-[var(--foreground)]">
+      <span className="text-xs text-[var(--text-secondary)]">{label}</span>
+      <span className="max-w-[70%] text-right text-xs font-medium text-[var(--text)]">
         {value ?? fallback}
       </span>
     </div>
@@ -40,26 +34,26 @@ export default function TaskDetail({
   detailError,
   outputItems,
   outputError,
-}: TaskDetailProps) {
+}: Props) {
   const t = useT();
   const metadataFallback = t('pages.tasks.unavailable');
 
   if (detailError) {
     return (
-      <section className="flex min-h-0 flex-1 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--card)] p-6">
-        <p className="text-sm text-[var(--destructive)]">{detailError}</p>
+      <section className="flex min-h-0 flex-1 items-center justify-center rounded-xl border border-[var(--border)] bg-[var(--surface)] p-6">
+        <p className="text-sm text-[#ff3b30]">{detailError}</p>
       </section>
     );
   }
 
   if (!selectedTask) {
     return (
-      <section className="flex min-h-0 flex-1 items-center justify-center rounded-xl border border-dashed border-[var(--border)] bg-[var(--card)] p-6">
+      <section className="flex min-h-0 flex-1 items-center justify-center rounded-xl border border-dashed border-[var(--border)] bg-[var(--surface)] p-6">
         <div className="max-w-sm text-center">
-          <h2 className="text-base font-semibold text-[var(--foreground)]">
+          <h2 className="text-base font-semibold text-[var(--text)]">
             {t('pages.tasks.noTaskSelected')}
           </h2>
-          <p className="mt-2 text-sm text-[var(--muted-foreground)]">
+          <p className="mt-2 text-sm text-[var(--text-secondary)]">
             {t('pages.tasks.noTaskSelectedDescription')}
           </p>
         </div>
@@ -68,17 +62,17 @@ export default function TaskDetail({
   }
 
   return (
-    <section className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)] shadow-[var(--shadow-pane)]">
+    <section className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--surface)] shadow-sm">
       <header className="border-b border-[var(--border)] px-5 py-4">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="min-w-0">
-            <p className="text-xs font-medium uppercase tracking-wide text-[var(--muted-foreground)]">
+            <p className="text-xs font-medium uppercase tracking-wide text-[var(--text-secondary)]">
               {t('pages.tasks.workspaceEyebrow')}
             </p>
-            <h1 className="mt-1 truncate text-xl font-semibold tracking-tight text-[var(--foreground)]">
+            <h1 className="mt-1 truncate text-xl font-semibold tracking-tight text-[var(--text)]">
               {selectedTask.title}
             </h1>
-            <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+            <p className="mt-1 text-sm text-[var(--text-secondary)]">
               {selectedTask.workspace_summary.label} · {selectedTask.environment_summary.alias} ·{' '}
               {selectedTask.environment_summary.display_name}
             </p>
@@ -90,9 +84,9 @@ export default function TaskDetail({
           </span>
         </div>
         {selectedTask.error_summary ? (
-          <p className="mt-3 rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-sm text-red-600">
+          <Alert variant="error" className="mt-3">
             {selectedTask.error_summary}
-          </p>
+          </Alert>
         ) : null}
       </header>
 
@@ -100,14 +94,14 @@ export default function TaskDetail({
         <main className="min-h-0 overflow-auto p-5">
           <section className="space-y-3">
             <div className="flex items-center justify-between gap-3">
-              <h2 className="text-sm font-semibold text-[var(--foreground)]">
+              <h2 className="text-sm font-semibold text-[var(--text)]">
                 {t('pages.tasks.outputTimeline')}
               </h2>
-              <span className="text-xs text-[var(--muted-foreground)]">
+              <span className="text-xs text-[var(--text-secondary)]">
                 {t('pages.tasks.latestSeq', { seq: selectedTask.latest_output_seq })}
               </span>
             </div>
-            {outputError ? <p className="text-sm text-[var(--destructive)]">{outputError}</p> : null}
+            {outputError ? <p className="text-sm text-[#ff3b30]">{outputError}</p> : null}
             <div className="min-h-[24rem] space-y-3 rounded-xl border border-[var(--border)] bg-[#0b1020] p-4 text-xs text-gray-100">
               {outputItems.length === 0 ? (
                 <p className="text-gray-400">{t('pages.tasks.noOutput')}</p>
@@ -125,7 +119,7 @@ export default function TaskDetail({
           </section>
 
           <section className="mt-5 space-y-3">
-            <h2 className="text-sm font-semibold text-[var(--foreground)]">
+            <h2 className="text-sm font-semibold text-[var(--text)]">
               {t('pages.tasks.promptLayers')}
             </h2>
             {selectedTask.prompt ? (
@@ -133,35 +127,35 @@ export default function TaskDetail({
                 {selectedTask.prompt.layers.map((layer) => (
                   <details
                     key={layer.name}
-                    className="rounded-xl border border-[var(--border)] bg-[var(--background)] p-4"
+                    className="rounded-xl border border-[var(--border)] bg-[var(--bg)] p-4"
                   >
-                    <summary className="cursor-pointer text-sm font-medium text-[var(--foreground)]">
+                    <summary className="cursor-pointer text-sm font-medium text-[var(--text)]">
                       {layer.label}{' '}
-                      <span className="text-xs text-[var(--muted-foreground)]">
+                      <span className="text-xs text-[var(--text-secondary)]">
                         ({layer.char_count} {t('pages.tasks.chars')})
                       </span>
                     </summary>
-                    <pre className="mt-3 overflow-x-auto rounded-lg bg-[var(--code-background)] p-3 text-xs text-[var(--code-foreground)]">
+                    <pre className="mt-3 overflow-x-auto rounded-lg bg-[var(--bg-tertiary)] p-3 text-xs text-[var(--text)]">
                       {layer.content}
                     </pre>
                   </details>
                 ))}
               </div>
             ) : (
-              <p className="text-sm text-[var(--muted-foreground)]">
+              <p className="text-sm text-[var(--text-secondary)]">
                 {t('pages.tasks.promptUnavailable')}
               </p>
             )}
           </section>
         </main>
 
-        <aside className="min-h-0 overflow-auto border-t border-[var(--border)] bg-[var(--background)] p-5 lg:border-l lg:border-t-0">
+        <aside className="min-h-0 overflow-auto border-t border-[var(--border)] bg-[var(--bg)] p-5 lg:border-l lg:border-t-0">
           <div className="space-y-5">
             <section>
-              <h2 className="mb-2 text-sm font-semibold text-[var(--foreground)]">
+              <h2 className="mb-2 text-sm font-semibold text-[var(--text)]">
                 {t('pages.tasks.summary')}
               </h2>
-              <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] px-3">
+              <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] px-3">
                 <MetadataRow label={t('pages.tasks.taskId')} value={selectedTask.task_id} fallback={metadataFallback} />
                 <MetadataRow label={t('pages.tasks.created')} value={selectedTask.created_at} fallback={metadataFallback} />
                 <MetadataRow label={t('pages.tasks.updated')} value={selectedTask.updated_at} fallback={metadataFallback} />
@@ -171,28 +165,28 @@ export default function TaskDetail({
             </section>
 
             <section>
-              <h2 className="mb-2 text-sm font-semibold text-[var(--foreground)]">
+              <h2 className="mb-2 text-sm font-semibold text-[var(--text)]">
                 {t('pages.tasks.binding')}
               </h2>
               {selectedTask.binding ? (
-                <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] px-3">
+                <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] px-3">
                   <MetadataRow label={t('pages.tasks.profile')} value={selectedTask.binding.task_profile} fallback={metadataFallback} />
                   <MetadataRow label={t('pages.tasks.workdir')} value={selectedTask.binding.resolved_workdir} fallback={metadataFallback} />
                   <MetadataRow label={t('pages.tasks.snapshot')} value={selectedTask.binding.snapshot_path} fallback={metadataFallback} />
                 </div>
               ) : (
-                <p className="text-sm text-[var(--muted-foreground)]">
+                <p className="text-sm text-[var(--text-secondary)]">
                   {t('pages.tasks.bindingUnavailable')}
                 </p>
               )}
             </section>
 
             <section>
-              <h2 className="mb-2 text-sm font-semibold text-[var(--foreground)]">
+              <h2 className="mb-2 text-sm font-semibold text-[var(--text)]">
                 {t('pages.tasks.runtime')}
               </h2>
               {selectedTask.runtime ? (
-                <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] px-3">
+                <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] px-3">
                   <MetadataRow label={t('pages.tasks.runner')} value={selectedTask.runtime.runner_kind} fallback={metadataFallback} />
                   <MetadataRow label={t('pages.tasks.directory')} value={selectedTask.runtime.working_directory} fallback={metadataFallback} />
                   <MetadataRow
@@ -202,17 +196,17 @@ export default function TaskDetail({
                   />
                 </div>
               ) : (
-                <p className="text-sm text-[var(--muted-foreground)]">
+                <p className="text-sm text-[var(--text-secondary)]">
                   {t('pages.tasks.runtimeUnavailable')}
                 </p>
               )}
             </section>
 
             <section>
-              <h2 className="mb-2 text-sm font-semibold text-[var(--foreground)]">
+              <h2 className="mb-2 text-sm font-semibold text-[var(--text)]">
                 {t('pages.tasks.result')}
               </h2>
-              <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] px-3">
+              <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] px-3">
                 <MetadataRow label={t('pages.tasks.exitCode')} value={selectedTask.result.exit_code} fallback={metadataFallback} />
                 <MetadataRow label={t('pages.tasks.failure')} value={selectedTask.result.failure_category} fallback={metadataFallback} />
                 <MetadataRow label={t('pages.tasks.completed')} value={selectedTask.result.completed_at} fallback={metadataFallback} />

--- a/frontend/src/pages/tasks/TaskList.tsx
+++ b/frontend/src/pages/tasks/TaskList.tsx
@@ -1,16 +1,9 @@
 import { Search } from 'lucide-react';
 import { useT } from '../../i18n';
-import type { TaskStatus, TaskSummary } from '../../types';
+import type { TaskSummary } from '../../types';
+import { statusClassName } from './status';
 
-const statusClassName: Record<TaskStatus, string> = {
-  queued: 'border-[var(--border)] bg-[var(--muted)] text-[var(--muted-foreground)]',
-  starting: 'border-blue-500/20 bg-blue-500/10 text-blue-600',
-  running: 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600',
-  succeeded: 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600',
-  failed: 'border-red-500/20 bg-red-500/10 text-red-600',
-};
-
-interface TaskListProps {
+interface Props {
   tasks: TaskSummary[];
   selectedTaskId: string | null;
   tasksError: string | null;
@@ -42,7 +35,7 @@ export default function TaskList({
   searchQuery,
   onSearchQueryChange,
   onSelectTask,
-}: TaskListProps) {
+}: Props) {
   const t = useT();
   const filteredTasks = tasks.filter((task) => matchesTask(task, searchQuery));
 
@@ -52,26 +45,26 @@ export default function TaskList({
         <span className="sr-only">{t('pages.tasks.searchLabel')}</span>
         <Search
           size={15}
-          className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[var(--muted-foreground)]"
+          className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-secondary)]"
         />
         <input
           aria-label={t('pages.tasks.searchLabel')}
           value={searchQuery}
           onChange={(event) => onSearchQueryChange(event.target.value)}
-          className="h-9 w-full rounded-lg border border-[var(--input)] bg-[var(--background)] pl-9 pr-3 text-sm text-[var(--foreground)] shadow-[var(--shadow-input)] outline-none transition placeholder:text-[var(--muted-foreground)] focus:border-[var(--accent)] focus:ring-2 focus:ring-[var(--ring)]"
+          className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] pl-9 pr-3 text-sm text-[var(--text)] outline-none transition placeholder:text-[var(--text-secondary)] focus:border-[var(--apple-blue)] focus:ring-2 focus:ring-[var(--apple-blue)]/15"
           placeholder={t('pages.tasks.searchPlaceholder')}
         />
       </label>
 
-      {tasksError ? <p className="mb-3 text-sm text-[var(--destructive)]">{tasksError}</p> : null}
+      {tasksError ? <p className="mb-3 text-sm text-[#ff3b30]">{tasksError}</p> : null}
 
       <div className="min-h-0 flex-1 space-y-1 overflow-auto pr-1">
         {tasks.length === 0 ? (
-          <div className="rounded-lg border border-dashed border-[var(--border)] bg-[var(--muted)] p-4 text-sm text-[var(--muted-foreground)]">
+          <div className="rounded-lg border border-dashed border-[var(--border)] bg-[var(--bg-secondary)] p-4 text-sm text-[var(--text-secondary)]">
             {t('pages.tasks.empty')}
           </div>
         ) : filteredTasks.length === 0 ? (
-          <div className="rounded-lg border border-dashed border-[var(--border)] bg-[var(--muted)] p-4 text-sm text-[var(--muted-foreground)]">
+          <div className="rounded-lg border border-dashed border-[var(--border)] bg-[var(--bg-secondary)] p-4 text-sm text-[var(--text-secondary)]">
             {t('pages.tasks.noSearchResults', { query: searchQuery })}
           </div>
         ) : (
@@ -85,12 +78,12 @@ export default function TaskList({
                 className={[
                   'flex w-full flex-col gap-2 rounded-lg border px-3 py-3 text-left transition',
                   isSelected
-                    ? 'border-[var(--accent)]/35 bg-[var(--accent)]/10 shadow-[var(--shadow-card)]'
-                    : 'border-transparent hover:border-[var(--border)] hover:bg-[var(--muted)]',
+                    ? 'border-[var(--apple-blue)]/35 bg-[var(--apple-blue)]/10 shadow-sm'
+                    : 'border-transparent hover:border-[var(--border)] hover:bg-[var(--bg-secondary)]',
                 ].join(' ')}
               >
                 <span className="flex items-start justify-between gap-2">
-                  <span className="min-w-0 text-sm font-medium leading-snug text-[var(--foreground)]">
+                  <span className="min-w-0 text-sm font-medium leading-snug text-[var(--text)]">
                     {task.title}
                   </span>
                   <span
@@ -99,7 +92,7 @@ export default function TaskList({
                     {t(`pages.tasks.status.${task.status}`)}
                   </span>
                 </span>
-                <span className="truncate text-xs text-[var(--muted-foreground)]">
+                <span className="truncate text-xs text-[var(--text-secondary)]">
                   {task.workspace_summary.label} · {task.environment_summary.alias}
                 </span>
                 <span className="truncate text-[11px] text-[var(--text-tertiary)]">

--- a/frontend/src/pages/tasks/status.ts
+++ b/frontend/src/pages/tasks/status.ts
@@ -1,0 +1,9 @@
+import type { TaskStatus } from '../../types';
+
+export const statusClassName: Record<TaskStatus, string> = {
+  queued: 'border-[var(--border)] bg-[var(--bg-secondary)] text-[var(--text-secondary)]',
+  starting: 'border-[var(--apple-blue)]/20 bg-[var(--apple-blue)]/10 text-[var(--apple-blue)]',
+  running: 'border-[#34c759]/20 bg-[#34c759]/10 text-[#2e7d32]',
+  succeeded: 'border-[#34c759]/20 bg-[#34c759]/10 text-[#2e7d32]',
+  failed: 'border-[#ff3b30]/20 bg-[#ff3b30]/10 text-[#c62828]',
+};

--- a/frontend/src/pages/workspaces/WorkspaceManagerCard.tsx
+++ b/frontend/src/pages/workspaces/WorkspaceManagerCard.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createWorkspace, deleteWorkspace, getWorkspaces, updateWorkspace } from '../../api';
 import { useT } from '../../i18n';
 import type { WorkspaceCreateRequest, WorkspaceRecord, WorkspaceUpdateRequest } from '../../types';
+import { SectionCard, SectionHeader, Button, FormField, Input, Textarea, Alert } from '../../components/ui';
 
 interface WorkspaceDraft {
   label: string;
@@ -106,36 +107,27 @@ export default function WorkspaceManagerCard() {
   const isBusy = createMutation.isPending || updateMutation.isPending || deleteMutation.isPending;
 
   return (
-    <section className="space-y-5 rounded-xl bg-[var(--surface)] p-6 shadow-sm">
+    <SectionCard>
       <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="space-y-1">
-          <h2
-            className="text-lg font-semibold leading-tight tracking-[0.231px] text-[var(--text)]"
-            style={{ fontFamily: 'var(--font-display)' }}
-          >
-            {t('pages.workspaces.managerTitle')}
-          </h2>
-          <p className="text-sm leading-relaxed tracking-[-0.224px] text-[var(--text-secondary)]">
-            {t('pages.workspaces.managerDescription')}
-          </p>
-        </div>
-        <button
-          type="button"
+        <SectionHeader
+          title={t('pages.workspaces.managerTitle')}
+          description={t('pages.workspaces.managerDescription')}
+        />
+        <Button
           onClick={() => {
             setIsCreating(true);
             setSelectedWorkspaceId(null);
           }}
-          className="rounded-lg bg-[var(--apple-blue)] px-4 py-2 text-sm font-medium text-white transition hover:bg-[var(--apple-blue-hover)]"
         >
           {t('pages.workspaces.newWorkspace')}
-        </button>
+        </Button>
       </div>
 
       {workspacesQuery.isLoading ? (
         <p className="text-sm text-[var(--text-tertiary)]">{t('common.loading')}</p>
       ) : null}
       {workspacesQuery.error instanceof Error ? (
-        <p className="text-sm text-[#ff3b30]">{workspacesQuery.error.message}</p>
+        <Alert variant="error">{workspacesQuery.error.message}</Alert>
       ) : null}
 
       <div className="grid gap-5 xl:grid-cols-[minmax(220px,320px)_1fr]">
@@ -179,93 +171,75 @@ export default function WorkspaceManagerCard() {
             }
           }}
         >
-          <label className="block space-y-2">
-            <span className="text-sm font-medium text-[var(--text)]">
-              {t('pages.workspaces.labelField')}
-            </span>
-            <input
+          <FormField label={t('pages.workspaces.labelField')}>
+            <Input
               aria-label={t('pages.workspaces.labelField')}
               required
               value={draft.label}
               onChange={(event) => setDraft((current) => ({ ...current, label: event.target.value }))}
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-4 py-3 text-sm text-[var(--text)] outline-none focus:border-[var(--apple-blue)]"
             />
-          </label>
-          <label className="block space-y-2">
-            <span className="text-sm font-medium text-[var(--text)]">
-              {t('pages.workspaces.descriptionField')}
-            </span>
-            <input
+          </FormField>
+          <FormField label={t('pages.workspaces.descriptionField')}>
+            <Input
               aria-label={t('pages.workspaces.descriptionField')}
               value={draft.description}
               onChange={(event) =>
                 setDraft((current) => ({ ...current, description: event.target.value }))
               }
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-4 py-3 text-sm text-[var(--text)] outline-none focus:border-[var(--apple-blue)]"
             />
-          </label>
-          <label className="block space-y-2">
-            <span className="text-sm font-medium text-[var(--text)]">
-              {t('pages.workspaces.defaultWorkdirField')}
-            </span>
-            <input
+          </FormField>
+          <FormField label={t('pages.workspaces.defaultWorkdirField')}>
+            <Input
               aria-label={t('pages.workspaces.defaultWorkdirField')}
               value={draft.default_workdir}
               onChange={(event) =>
                 setDraft((current) => ({ ...current, default_workdir: event.target.value }))
               }
-              className="w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-4 py-3 text-sm text-[var(--text)] outline-none focus:border-[var(--apple-blue)]"
             />
-          </label>
-          <label className="block space-y-2">
-            <span className="text-sm font-medium text-[var(--text)]">
-              {t('pages.workspaces.promptField')}
-            </span>
-            <textarea
+          </FormField>
+          <FormField label={t('pages.workspaces.promptField')}>
+            <Textarea
               aria-label={t('pages.workspaces.promptField')}
               required
               value={draft.workspace_prompt}
               onChange={(event) =>
                 setDraft((current) => ({ ...current, workspace_prompt: event.target.value }))
               }
-              className="min-h-32 w-full rounded-lg border border-[var(--border)] bg-[var(--bg)] px-4 py-3 text-sm text-[var(--text)] outline-none focus:border-[var(--apple-blue)]"
+              className="min-h-32"
             />
-          </label>
+          </FormField>
 
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div className="flex flex-wrap gap-3">
               {!isCreating && canDelete ? (
-                <button
+                <Button
                   type="button"
+                  variant="secondary"
                   onClick={() => setIsConfirmingDelete((current) => !current)}
-                  className="rounded-lg border border-[#ff3b30]/40 bg-[var(--bg)] px-4 py-2 text-sm font-medium text-[#ff3b30] transition hover:bg-[#ff3b30]/10"
+                  className="border-[#ff3b30]/40 text-[#ff3b30] hover:bg-[#ff3b30]/10 hover:text-[#ff3b30]"
                 >
                   {t('pages.workspaces.deleteWorkspace')}
-                </button>
+                </Button>
               ) : null}
               {isConfirmingDelete && selectedWorkspace ? (
-                <button
+                <Button
                   type="button"
+                  variant="danger"
                   onClick={() => deleteMutation.mutate(selectedWorkspace.workspace_id)}
                   disabled={isBusy}
-                  className="rounded-lg bg-[#ff3b30] px-4 py-2 text-sm font-medium text-white transition disabled:opacity-40"
                 >
                   {t('pages.workspaces.confirmDelete')}
-                </button>
+                </Button>
               ) : null}
             </div>
-            <button
-              type="submit"
-              disabled={isBusy}
-              className="rounded-lg bg-[var(--apple-blue)] px-4 py-2 text-sm font-medium text-white transition hover:bg-[var(--apple-blue-hover)] disabled:opacity-40"
-            >
+            <Button type="submit" disabled={isBusy}>
               {isCreating
                 ? t('pages.workspaces.createWorkspace')
                 : t('pages.workspaces.saveWorkspace')}
-            </button>
+            </Button>
           </div>
         </form>
       </div>
-    </section>
+    </SectionCard>
   );
 }

--- a/frontend/src/utils/error.ts
+++ b/frontend/src/utils/error.ts
@@ -1,0 +1,5 @@
+export function extractErrorMessage(error: unknown): string | null {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  return null;
+}


### PR DESCRIPTION
## Summary

This PR unifies the frontend UI by extracting reusable base components and migrating existing pages to use them, ensuring consistent design tokens and component conventions across the codebase.

## Changes

- **Extract reusable UI base components** (`frontend/src/components/ui/`)
  - Alert, Badge, Button, EmptyState, FormField, Input, PageHeader, SectionCard, SectionHeader, Select, StatusDot, Textarea
- **Migrate pages to standardized components**
  - ContainersPage, DashboardPage, FileBrowserPage, PlaceholderPage, SettingsPage, TasksPage, TerminalPage, WorkspacesPage
  - Task sub-pages: TaskCreateForm, TaskDetail, TaskList
  - Workspace sub-pages: WorkspaceManagerCard
- **Unify task page design tokens**
  - Standardize color, spacing, and typography conventions
  - Add shared `tasks/status.ts` and `utils/error.ts` utilities
- **Update dependent components**
  - ErrorBoundary, HealthStatusBar, EnvironmentSelectorPanel, FileViewer, TerminalBenchCardView

## Test plan

- [ ] Verify all affected pages render without visual regressions
- [ ] Confirm Button, Input, Select, and Badge variants display correctly
- [ ] Check Task create/detail/list flows work end-to-end
- [ ] Ensure Workspace manager card interactions remain intact
- [ ] Run frontend type checks and tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)