### PR TITLE
feat: Monaco editor auto-theme and configurable font settings

### DIFF
--- a/frontend/src/components/file-browser/FileViewer.tsx
+++ b/frontend/src/components/file-browser/FileViewer.tsx
@@ -1,7 +1,31 @@
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, useEffect, useState } from 'react';
 import type { FileReadResponse } from '../../types';
+import { useEditorSettings } from '../../settings';
 
 const MonacoEditor = lazy(() => import('@monaco-editor/react'));
+
+function useSystemColorScheme(): 'light' | 'dark' {
+  const [scheme, setScheme] = useState<'light' | 'dark'>(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return 'light';
+    }
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return;
+    }
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (event: MediaQueryListEvent) => {
+      setScheme(event.matches ? 'dark' : 'light');
+    };
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  return scheme;
+}
 
 interface Props {
   file: FileReadResponse | null;
@@ -9,6 +33,9 @@ interface Props {
 }
 
 export default function FileViewer({ file, isLoading }: Props) {
+  const colorScheme = useSystemColorScheme();
+  const editorSettings = useEditorSettings();
+
   if (isLoading) {
     return (
       <div className="flex h-full items-center justify-center text-sm text-[var(--text-tertiary)]">
@@ -63,11 +90,13 @@ export default function FileViewer({ file, isLoading }: Props) {
           height="100%"
           language={file.language || 'plaintext'}
           value={file.content}
+          theme={colorScheme === 'dark' ? 'vs-dark' : 'vs'}
           options={{
             readOnly: true,
             minimap: { enabled: false },
             scrollBeyondLastLine: false,
-            fontSize: 13,
+            fontSize: editorSettings.fontSize,
+            fontFamily: editorSettings.fontFamily,
             wordWrap: 'on',
           }}
         />

--- a/frontend/src/i18n/messages.ts
+++ b/frontend/src/i18n/messages.ts
@@ -254,6 +254,10 @@ export const messages = {
           terminalFontSizeLabel: 'Terminal font size',
           terminalFontSizeHelp:
             'Font size is clamped to a stable range of {{min}}-{{max}} px. Current save value: {{current}} px.',
+          editorFontSizeLabel: 'Editor font size',
+          editorFontFamilyLabel: 'Editor font family',
+          editorFontSizeHelp:
+            'Editor font size is clamped to {{min}}-{{max}} px. Current save value: {{current}} px.',
         },
         codeServerInstall: {
           title: 'Code-server installer',
@@ -740,6 +744,10 @@ export const messages = {
           terminalFontSizeLabel: '终端字号',
           terminalFontSizeHelp:
             '字号会被限制在稳定区间 {{min}}-{{max}} px，当前保存值为 {{current}} px。',
+          editorFontSizeLabel: '编辑器字号',
+          editorFontFamilyLabel: '编辑器字体',
+          editorFontSizeHelp:
+            '编辑器字号会被限制在 {{min}}-{{max}} px，当前保存值为 {{current}} px。',
         },
         codeServerInstall: {
           title: 'code-server 安装器',

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -16,8 +16,11 @@ import { EnvironmentSelectorPanel, useEnvironmentSelection } from '../components
 import { getEnvironments, getSkills, getWorkspaces } from '../api';
 import { useT } from '../i18n';
 import {
+  clampEditorFontSize,
   clampTerminalFontSize,
+  maxEditorFontSize,
   maxTerminalFontSize,
+  minEditorFontSize,
   minTerminalFontSize,
   useSettings,
 } from '../settings';
@@ -33,6 +36,8 @@ import type { EnvironmentRecord, SkillItem } from '../types';
 interface GeneralDraftState {
   defaultRoute: DefaultRoute;
   terminalFontSize: string;
+  editorFontSize: string;
+  editorFontFamily: string;
 }
 
 interface GeneralPreferencesSectionProps {
@@ -92,11 +97,16 @@ function GeneralPreferencesSection({
   const [draft, setDraft] = useState<GeneralDraftState>({
     defaultRoute: savedGeneral.defaultRoute,
     terminalFontSize: String(savedGeneral.terminal.fontSize),
+    editorFontSize: String(savedGeneral.editor.fontSize),
+    editorFontFamily: savedGeneral.editor.fontFamily,
   });
-  const clampedFontSize = clampTerminalFontSize(Number.parseInt(draft.terminalFontSize, 10));
+  const clampedTerminalFontSize = clampTerminalFontSize(Number.parseInt(draft.terminalFontSize, 10));
+  const clampedEditorFontSize = clampEditorFontSize(Number.parseInt(draft.editorFontSize, 10));
   const hasChanges =
     draft.defaultRoute !== savedGeneral.defaultRoute ||
-    clampedFontSize !== savedGeneral.terminal.fontSize;
+    clampedTerminalFontSize !== savedGeneral.terminal.fontSize ||
+    clampedEditorFontSize !== savedGeneral.editor.fontSize ||
+    draft.editorFontFamily !== savedGeneral.editor.fontFamily;
 
   return (
     <SectionCard
@@ -144,6 +154,37 @@ function GeneralPreferencesSection({
             }
           />
         </FormField>
+
+        <FormField label={t('pages.settings.general.editorFontSizeLabel')}>
+          <Input
+            aria-label={t('pages.settings.general.editorFontSizeLabel')}
+            type="number"
+            min={minEditorFontSize}
+            max={maxEditorFontSize}
+            step={1}
+            value={draft.editorFontSize}
+            onChange={(event) =>
+              setDraft((current) => ({
+                ...current,
+                editorFontSize: event.target.value,
+              }))
+            }
+          />
+        </FormField>
+
+        <FormField label={t('pages.settings.general.editorFontFamilyLabel')}>
+          <Input
+            aria-label={t('pages.settings.general.editorFontFamilyLabel')}
+            type="text"
+            value={draft.editorFontFamily}
+            onChange={(event) =>
+              setDraft((current) => ({
+                ...current,
+                editorFontFamily: event.target.value,
+              }))
+            }
+          />
+        </FormField>
       </div>
 
       <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg bg-[var(--bg-secondary)] px-4 py-3 text-sm tracking-[-0.224px] text-[var(--text-secondary)]">
@@ -151,7 +192,13 @@ function GeneralPreferencesSection({
           {t('pages.settings.general.terminalFontSizeHelp', {
             min: minTerminalFontSize,
             max: maxTerminalFontSize,
-            current: clampedFontSize,
+            current: clampedTerminalFontSize,
+          })}
+          {' / '}
+          {t('pages.settings.general.editorFontSizeHelp', {
+            min: minEditorFontSize,
+            max: maxEditorFontSize,
+            current: clampedEditorFontSize,
           })}
         </p>
         <div className="flex flex-wrap gap-3">
@@ -163,7 +210,11 @@ function GeneralPreferencesSection({
               onSave({
                 defaultRoute: draft.defaultRoute,
                 terminal: {
-                  fontSize: clampedFontSize,
+                  fontSize: clampedTerminalFontSize,
+                },
+                editor: {
+                  fontSize: clampedEditorFontSize,
+                  fontFamily: draft.editorFontFamily || 'monospace',
                 },
               })
             }

--- a/frontend/src/settings/context.tsx
+++ b/frontend/src/settings/context.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react-refresh/only-export-components */
 import { createContext, useContext, useMemo, useState, type ReactNode } from 'react';
 import {
+  clampEditorFontSize,
   clampTerminalFontSize,
   createDefaultTaskConfigurationSettings,
   createDefaultWebUiSettings,
@@ -48,6 +49,12 @@ interface SettingsState {
 }
 
 function sanitizeSettings(settings: WebUiSettingsDocument): WebUiSettingsDocument {
+  const editorFontSize = clampEditorFontSize(settings.general.editor?.fontSize);
+  const editorFontFamily =
+    typeof settings.general.editor?.fontFamily === 'string' &&
+    settings.general.editor.fontFamily.length > 0
+      ? settings.general.editor.fontFamily
+      : 'monospace';
   return {
     version: 2,
     general: {
@@ -56,6 +63,10 @@ function sanitizeSettings(settings: WebUiSettingsDocument): WebUiSettingsDocumen
         : 'terminal',
       terminal: {
         fontSize: clampTerminalFontSize(settings.general.terminal.fontSize),
+      },
+      editor: {
+        fontSize: editorFontSize,
+        fontFamily: editorFontFamily,
       },
     },
     taskConfiguration: settings.taskConfiguration,
@@ -96,6 +107,10 @@ export function SettingsProvider({ children }: ProviderProps) {
             defaultRoute: general.defaultRoute,
             terminal: {
               fontSize: general.terminal.fontSize,
+            },
+            editor: {
+              fontSize: general.editor.fontSize,
+              fontFamily: general.editor.fontFamily,
             },
           },
         });
@@ -236,6 +251,14 @@ export function useSettings(): SettingsContextValue {
 
 export function useTerminalFontSize(): number {
   return useSettings().settings.general.terminal.fontSize;
+}
+
+export function useEditorSettings(): { fontSize: number; fontFamily: string } {
+  const { settings } = useSettings();
+  return {
+    fontSize: settings.general.editor.fontSize,
+    fontFamily: settings.general.editor.fontFamily,
+  };
 }
 
 export function useProjectEnvironmentDefaults(environmentId: string | null): EnvironmentTaskDefaults {

--- a/frontend/src/settings/defaults.ts
+++ b/frontend/src/settings/defaults.ts
@@ -12,6 +12,10 @@ export const settingsStorageKey = 'scholar-agent:webui-settings';
 export const defaultTerminalFontSize = 13;
 export const minTerminalFontSize = 11;
 export const maxTerminalFontSize = 18;
+export const defaultEditorFontSize = 14;
+export const minEditorFontSize = 10;
+export const maxEditorFontSize = 24;
+export const defaultEditorFontFamily = 'monospace';
 export const defaultResearchAgentProfileId = 'claude-code-default';
 export const rawPromptTaskConfigurationId = 'raw-prompt';
 export const structuredResearchTaskConfigurationId = 'structured-research-default';
@@ -29,6 +33,15 @@ export function clampTerminalFontSize(value: unknown): number {
 
   const rounded = Math.round(value);
   return Math.min(maxTerminalFontSize, Math.max(minTerminalFontSize, rounded));
+}
+
+export function clampEditorFontSize(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return defaultEditorFontSize;
+  }
+
+  const rounded = Math.round(value);
+  return Math.min(maxEditorFontSize, Math.max(minEditorFontSize, rounded));
 }
 
 export function createDefaultResearchAgentProfile(): ResearchAgentProfileSettings {
@@ -95,6 +108,10 @@ export function createDefaultWebUiSettings(): WebUiSettingsDocument {
       defaultRoute: 'terminal',
       terminal: {
         fontSize: defaultTerminalFontSize,
+      },
+      editor: {
+        fontSize: defaultEditorFontSize,
+        fontFamily: defaultEditorFontFamily,
       },
     },
     taskConfiguration: createDefaultTaskConfigurationSettings(),

--- a/frontend/src/settings/index.ts
+++ b/frontend/src/settings/index.ts
@@ -1,17 +1,22 @@
 export {
+  clampEditorFontSize,
   clampTerminalFontSize,
   createDefaultTaskConfigurationSettings,
   createDefaultWebUiSettings,
   createEmptyEnvironmentTaskDefaults,
+  defaultEditorFontFamily,
+  defaultEditorFontSize,
   defaultResearchAgentProfileId,
   defaultTerminalFontSize,
+  maxEditorFontSize,
   maxTerminalFontSize,
+  minEditorFontSize,
   minTerminalFontSize,
   rawPromptTaskConfigurationId,
   settingsStorageKey,
   structuredResearchTaskConfigurationId,
 } from './defaults';
-export { SettingsProvider, useSettings, useTerminalFontSize } from './context';
+export { SettingsProvider, useEditorSettings, useSettings, useTerminalFontSize } from './context';
 export { readStoredSettings, resolveProjectEnvironmentDefaults } from './storage';
 export type {
   DefaultRoute,

--- a/frontend/src/settings/storage.ts
+++ b/frontend/src/settings/storage.ts
@@ -1,9 +1,11 @@
 import {
+  clampEditorFontSize,
   clampTerminalFontSize,
   createDefaultProjectSettings,
   createDefaultTaskConfigurationSettings,
   createDefaultWebUiSettings,
   createEmptyEnvironmentTaskDefaults,
+  defaultEditorFontFamily,
   defaultResearchAgentProfileId,
   isDefaultRoute,
   rawPromptTaskConfigurationId,
@@ -259,7 +261,13 @@ export function readStoredSettings(): SettingsLoadResult {
     ? general.defaultRoute
     : defaults.general.defaultRoute;
   const terminalSettings = isRecord(general.terminal) ? general.terminal : null;
-  const fontSize = clampTerminalFontSize(terminalSettings?.fontSize);
+  const terminalFontSize = clampTerminalFontSize(terminalSettings?.fontSize);
+  const editorSettings = isRecord(general.editor) ? general.editor : null;
+  const editorFontSize = clampEditorFontSize(editorSettings?.fontSize);
+  const editorFontFamily =
+    typeof editorSettings?.fontFamily === 'string' && editorSettings.fontFamily.length > 0
+      ? editorSettings.fontFamily
+      : defaultEditorFontFamily;
 
   const missingDefaultRoute = general.defaultRoute === undefined;
   const invalidDefaultRoute = general.defaultRoute !== undefined && !isDefaultRoute(general.defaultRoute);
@@ -267,6 +275,11 @@ export function readStoredSettings(): SettingsLoadResult {
   const invalidTerminalFontSize =
     terminalSettings?.fontSize !== undefined &&
     clampTerminalFontSize(terminalSettings.fontSize) !== terminalSettings.fontSize;
+  const missingEditorSettings =
+    parsed.version === 2 && (editorSettings === null || editorSettings.fontSize === undefined);
+  const invalidEditorFontSize =
+    editorSettings?.fontSize !== undefined &&
+    clampEditorFontSize(editorSettings.fontSize) !== editorSettings.fontSize;
 
   return {
     settings: {
@@ -274,7 +287,11 @@ export function readStoredSettings(): SettingsLoadResult {
       general: {
         defaultRoute,
         terminal: {
-          fontSize,
+          fontSize: terminalFontSize,
+        },
+        editor: {
+          fontSize: editorFontSize,
+          fontFamily: editorFontFamily,
         },
       },
       taskConfiguration,
@@ -288,7 +305,9 @@ export function readStoredSettings(): SettingsLoadResult {
       missingDefaultRoute ||
       invalidDefaultRoute ||
       missingTerminalSettings ||
-      invalidTerminalFontSize
+      invalidTerminalFontSize ||
+      missingEditorSettings ||
+      invalidEditorFontSize
         ? 'invalid_document'
         : null,
   };

--- a/frontend/src/settings/types.ts
+++ b/frontend/src/settings/types.ts
@@ -52,6 +52,10 @@ export interface WebUiSettingsDocument {
     terminal: {
       fontSize: number;
     };
+    editor: {
+      fontSize: number;
+      fontFamily: string;
+    };
   };
   taskConfiguration: TaskConfigurationSettings;
   projectDefaults: {


### PR DESCRIPTION
## Summary
- Monaco editor now auto-switches between 'vs' (light) and 'vs-dark' (dark) themes based on system `prefers-color-scheme`
- Add `useSystemColorScheme` hook with `matchMedia` listener in `FileViewer`
- Add editor font size (10–24 px) and font family settings under `general.editor`
- Settings page now has editor font size and font family inputs alongside terminal font size
- Follow existing `terminal.fontSize` pattern: types, defaults, storage normalization, context sanitize/save/reset, and SettingsPage UI
- Add i18n labels in English and Chinese

## Test plan
- [ ] Toggle system dark/light mode and verify Monaco editor theme switches
- [ ] Change editor font size in Settings and verify it applies to FileViewer
- [ ] Change editor font family in Settings and verify it applies to FileViewer
- [ ] Verify settings persist across page reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)