### PR TITLE
feat: AINRF resource monitoring page

### DIFF
--- a/docs/LLM-Working/worklog/2026-05-06.md
+++ b/docs/LLM-Working/worklog/2026-05-06.md
@@ -74,3 +74,24 @@
 - `cd frontend && node_modules/.bin/tsc -b` 无错误
 - `uv run ruff check src/ainrf/skills/ tests/skills/ src/ainrf/api/routes/skills.py tests/api/test_skills.py src/ainrf/task_harness/` 全部通过
 - Commit: `8ee8d94`
+
+## 2026-05-06 13:42 UTC — PR Review: feat/AINRF resource monitoring page
+
+**Review scope:** Comprehensive review of PR "feat: AINRF resource monitoring page" (9 commits: monitor models, collectors, service, API route, frontend types/components/page, tests).
+
+**Issues found and fixed:**
+
+1. **Critical — camelCase/snake_case type mismatch**: Frontend TypeScript types for resource data used camelCase (`utilizationPercent`, `coreCount`, `ainrfProcesses`, etc.) while the backend Pydantic models serialize as snake_case (`utilization_percent`, `core_count`, `ainrf_processes`, etc.). This would cause all resource data to display as `undefined` in the browser. Fixed by updating all frontend interfaces, component field accesses, mocks, and tests to use snake_case — consistent with the rest of the project's TypeScript types.
+
+2. **Medium — Wrong `ps` column for memory**: The `ps` command used `pmem` (memory as % of total RAM), but the parser stored the result as `memory_mb`. `int(float("0.5"))` = 0, so all process memory would show as 0 MB. Fixed by switching to `rss` (resident set size in KB) and dividing by 1024 to get MB.
+
+3. **Medium — CPU % calculation wrong**: `LocalCollector` summed `pcpu` (per-core %) across all processes and stored the raw sum in `CpuInfo.percent`. On a 32-core system, the total could exceed 3200%, while the frontend cap `Math.min(percent, 100)` for the ring arc masked the visual bug but showed "3200%" in the label. Fixed by dividing the sum by `core_count` to get a normalised 0–100% system load estimate.
+
+4. **Medium — RemoteCollector hardcoded core_count=1**: Added `_collect_core_count()` method using `nproc` over SSH, matching the normalisation fix above.
+
+5. **Code quality — Duplicate `ResourcesResponse` in `schemas.py`**: A weakly-typed stub (`list[dict[str, object]]`) was appended to `schemas.py` in addition to the properly-typed version in `monitor/models.py`. The route already imported from `models.py`; the duplicate in `schemas.py` was removed.
+
+**Validation:**
+- `cd frontend && node_modules/.bin/tsc -b` — clean
+- `cd frontend && node_modules/.bin/vitest run src/pages/ResourcesPage.test.tsx` — 5/5 tests pass
+- Commits produced: see PR

--- a/docs/superpowers/specs/2026-05-06-ui-improvements-design.md
+++ b/docs/superpowers/specs/2026-05-06-ui-improvements-design.md
@@ -1,0 +1,219 @@
+# UI 改进设计文档
+
+## 概述
+
+本次改动包含三个独立但同在前端范围内的 UI 改进需求：
+
+1. 新建任务对话框右上角添加关闭按钮
+2. default 工作空间的根目录改为 `~/.ainrf_workspaces/default/`（后端自动创建）
+3. 环境探测结果展示优化：长文本改为"成功"/"失败"超链接，点击打开模态框展示分组卡片式详细信息
+
+## 方案选择
+
+采用**方案 C（完整重构 + 动画）**：
+- 提取通用 `Modal` 组件，统一所有模态框行为（focus trap、Escape 关闭、backdrop 点击关闭、进入/退出动画）
+- 环境探测详情使用独立可复用组件 `EnvironmentDetectionModal`
+- CSS transition 实现动画，不引入额外依赖
+
+## 1. 通用 Modal 组件
+
+### 文件
+
+`frontend/src/components/ui/Modal.tsx`
+
+### Props
+
+| 属性 | 类型 | 默认值 | 说明 |
+|---|---|---|---|
+| `isOpen` | `boolean` | — | 控制显隐 |
+| `onClose` | `() => void` | — | 关闭回调 |
+| `title` | `string \| null` | `null` | 标题（可选） |
+| `children` | `ReactNode` | — | 内容 |
+| `size` | `'sm' \| 'md' \| 'lg' \| 'xl'` | `'md'` | 宽度预设 |
+| `showCloseButton` | `boolean` | `true` | 是否显示右上角 X 按钮 |
+| `closeOnBackdropClick` | `boolean` | `true` | 点击 backdrop 是否关闭 |
+
+### 内部实现
+
+- Backdrop：`fixed inset-0 z-50 bg-black/45`
+- Dialog 容器：`z-50 flex items-center justify-center p-4`
+- Dialog 内容：`rounded-2xl border border-[var(--border)] bg-[var(--surface)] shadow-2xl`
+- Focus trap：封装为 hook `useFocusTrap`，基于现有 `trapDialogFocus` 逻辑
+- Escape 键关闭：监听 `keydown`
+- 关闭按钮：`lucide-react` 的 `X` 图标，位于标题栏右侧
+
+### 动画
+
+CSS transition，不引入动画库：
+
+- **进入**：
+  - backdrop：`opacity 0 → 1`，150ms
+  - dialog：`scale(0.96) opacity-0 → scale(1) opacity-100`，200ms ease-out
+- **退出**：
+  - 反向动画，150ms
+- 控制方式：React state `isClosing` + `onTransitionEnd`，退出动画完成后从 DOM 移除
+
+### Hook
+
+`frontend/src/hooks/useFocusTrap.ts`
+
+接收一个 `containerRef: RefObject<HTMLElement>`，在 mount 时自动 focus 第一个可聚焦元素，监听 Tab/Shift+Tab 实现循环焦点。
+
+## 2. 新建任务对话框关闭按钮
+
+### 改动点
+
+- `TasksPage.tsx` 中的 inline modal 逻辑替换为 `<Modal>` 组件
+- `showCloseButton={true}`（默认），自动获得右上角 X 按钮
+- 关闭行为与现有 Escape 键行为一致：调用 `closeCreateDialog`，关闭后将焦点恢复至"新建任务"按钮
+
+### 代码变更
+
+```tsx
+// TasksPage.tsx 中替换以下 inline 结构：
+{isCreateDialogOpen ? (
+  <div className="fixed inset-0 z-50 ...">...</div>
+) : null}
+
+// 替换为：
+<Modal
+  isOpen={isCreateDialogOpen}
+  onClose={closeCreateDialog}
+  title={t('pages.tasks.createTitle')}
+  size="xl"
+>
+  <TaskCreateForm ... />
+</Modal>
+```
+
+## 3. Default 工作空间目录
+
+### 需求
+
+default 工作空间（seed workspace）的根目录从 `{cwd}/workspace/default` 改为 `~/.ainrf_workspaces/default/`，后端在初始化时自动创建。
+
+### 后端改动
+
+**文件：** `src/ainrf/runtime/paths.py`
+
+修改 `RuntimePathConfig.default_workspace_dir` 属性：
+
+```python
+@property
+def default_workspace_dir(self) -> Path:
+    return Path.home() / ".ainrf_workspaces" / "default"
+```
+
+`ensure_default_workspace_dir()` 方法保持不变（`mkdir(parents=True, exist_ok=True)`），路径变更后自动在新位置创建目录。
+
+**文件：** `src/ainrf/workspaces/service.py`
+
+`_build_seed_workspace()` 方法中 `default_workdir_path` 的获取逻辑不需要改动，因为 `self._default_workspace_dir` 已由 `RuntimePathConfig` 提供正确路径。
+
+### 数据迁移
+
+- 现有安装：若已有 `{cwd}/workspace/default` 目录且包含数据，本次改动仅影响新创建的文件。现有工作空间记录中的 `default_workdir` 字段保持原值。
+- 新安装：seed workspace 的 `default_workdir` 自动指向 `~/.ainrf_workspaces/default/`。
+
+## 4. 环境探测结果 Modal
+
+### 文件
+
+`frontend/src/components/environment/EnvironmentDetectionModal.tsx`
+
+### Props
+
+```ts
+interface EnvironmentDetectionModalProps {
+  detection: EnvironmentDetection;
+  environmentName: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+```
+
+### 分组卡片布局
+
+共 6 个分组，每组用卡片/分区包装：
+
+| 分组 | 键 | 包含字段 |
+|---|---|---|
+| 基本信息 | `basicInfo` | ssh_ok, hostname, os_info, arch, workdir_exists |
+| Python 工具链 | `pythonToolchain` | python, conda, uv, pixi |
+| 开发工具 | `devTools` | code_server, claude_cli |
+| AI/ML 环境 | `aiMl` | torch, cuda |
+| GPU 信息 | `gpu` | gpu_models, gpu_count |
+| 环境变量 | `envVars` | anthropic_env |
+
+### 每组内部布局
+
+- 组标题：小字大写 + 底部细线分隔
+- 每行：左侧标签（`text-secondary`，固定宽度）+ 右侧值（`text`）
+- 布尔/状态值：彩色 `StatusDot`（已有组件）
+  - 可用/成功：`--success`（绿色）
+  - 不可用/失败：`--error`（红色）
+- 版本号：`<code>` 标签
+- 路径：`<code>` 标签，过长时 `truncate`
+
+### 整体状态条
+
+Modal 顶部根据 `detection.status` 显示彩色状态条：
+
+- `success` → 绿色
+- `partial` → 橙色
+- `failed` → 红色
+
+### 错误与警告
+
+- `errors.length > 0` → 底部红色 Alert 列表
+- `warnings.length > 0` → 底部橙色 Alert 列表
+
+### 父组件改动
+
+**文件：** `frontend/src/pages/EnvironmentsPage.tsx`
+
+- 新增 state：`selectedDetectionEnvironmentId: string | null`
+- 探测结果列文本替换为超链接：
+  ```tsx
+  <button
+    className="text-sm font-medium text-[var(--apple-blue)] hover:underline"
+    onClick={() => setSelectedDetectionEnvironmentId(environment.id)}
+  >
+    {detectionStatusLabels[detection.status]}
+  </button>
+  ```
+- 新增 `<EnvironmentDetectionModal>` 渲染（条件：`selectedDetectionEnvironmentId !== null`）
+
+## 5. i18n 新增翻译键
+
+**文件：** `frontend/src/i18n/messages.ts`
+
+新增以下键（中英文）：
+
+- `components.modal.close` — 关闭按钮 aria-label
+- `components.environmentDetectionModal.title` — Modal 标题模板
+- `components.environmentDetectionModal.groups.basicInfo`
+- `components.environmentDetectionModal.groups.pythonToolchain`
+- `components.environmentDetectionModal.groups.devTools`
+- `components.environmentDetectionModal.groups.aiMl`
+- `components.environmentDetectionModal.groups.gpu`
+- `components.environmentDetectionModal.groups.envVars`
+- `components.environmentDetectionModal.labels.ssh` 等（每个字段一个标签键）
+
+## 6. 文件变更清单
+
+| 操作 | 文件路径 |
+|---|---|
+| 新增 | `frontend/src/components/ui/Modal.tsx` |
+| 新增 | `frontend/src/hooks/useFocusTrap.ts` |
+| 新增 | `frontend/src/components/environment/EnvironmentDetectionModal.tsx` |
+| 修改 | `frontend/src/pages/TasksPage.tsx` |
+| 修改 | `frontend/src/pages/EnvironmentsPage.tsx` |
+| 修改 | `src/ainrf/runtime/paths.py` |
+| 修改 | `frontend/src/i18n/messages.ts` |
+
+## 7. 测试考虑
+
+- `Modal` 组件：focus trap 行为、Escape 关闭、backdrop 点击关闭
+- `EnvironmentDetectionModal`：各分组正确渲染、状态颜色正确
+- 后端：路径变更后 `ensure_default_workspace_dir()` 正确创建目录

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ const TasksPage = lazy(() => import('./pages/TasksPage'));
 const EnvironmentsPage = lazy(() => import('./pages/EnvironmentsPage'));
 const WorkspacesPage = lazy(() => import('./pages/WorkspacesPage'));
 const FileBrowserPage = lazy(() => import('./pages/FileBrowserPage'));
+const ResourcesPage = lazy(() => import('./pages/ResourcesPage'));
 const SettingsPage = lazy(() => import('./pages/SettingsPage'));
 
 const queryClient = createAppQueryClient();
@@ -49,6 +50,7 @@ function AppRoutes() {
           <Route path="/workspaces" element={<WorkspacesPage />} />
           <Route path="/workspace-browser" element={<FileBrowserPage />} />
           <Route path="/environments" element={<EnvironmentsPage />} />
+          <Route path="/resources" element={<ResourcesPage />} />
           <Route path="/settings" element={<SettingsPage />} />
         </Routes>
       </Suspense>

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -33,6 +33,7 @@ import type {
   WorkspaceListResponse,
   WorkspaceRecord,
   WorkspaceUpdateRequest,
+  ResourcesResponse,
 } from '../types';
 import {
   mockArchiveTask,
@@ -77,6 +78,7 @@ import {
   mockUpdateProject,
   mockUpdateProjectEnvironmentReference,
   mockUpdateWorkspace,
+  mockGetResources,
 } from './mock';
 
 const USE_MOCK = import.meta.env.VITE_USE_MOCK === 'true';
@@ -360,3 +362,6 @@ export const readFile = (
           workspaceId ? `&workspace_id=${encodeURIComponent(workspaceId)}` : ''
         }`
       );
+
+export const getResources = (): Promise<ResourcesResponse> =>
+  USE_MOCK ? Promise.resolve(mockGetResources()) : api.get<ResourcesResponse>('/resources');

--- a/frontend/src/api/mock.ts
+++ b/frontend/src/api/mock.ts
@@ -36,6 +36,7 @@ import type {
   WorkspaceListResponse,
   WorkspaceRecord,
   WorkspaceUpdateRequest,
+  ResourcesResponse,
 } from '../types';
 
 const DEFAULT_PROJECT_ID = 'default';
@@ -1146,6 +1147,34 @@ export function resetMockTaskState(): TaskListResponse {
   mockTasks = {};
   mockTaskOutputs = {};
   return mockGetTasks();
+}
+
+export function mockGetResources(): ResourcesResponse {
+  return {
+    items: [
+      {
+        environmentId: 'env-localhost',
+        environmentName: 'Localhost',
+        timestamp: new Date().toISOString(),
+        status: 'ok',
+        gpus: [
+          {
+            index: 0,
+            name: 'NVIDIA GeForce RTX 4090',
+            utilizationPercent: 45.0,
+            memoryUsedMB: 8192,
+            memoryTotalMB: 24576,
+          },
+        ],
+        cpu: { percent: 23.5, coreCount: 32 },
+        memory: { usedMB: 16384, totalMB: 65536, percent: 25.0 },
+        ainrfProcesses: [
+          { pid: 12345, name: 'ainrf', cpuPercent: 5.2, memoryMB: 512, runtimeSeconds: 3600 },
+          { pid: 12346, name: 'python', cpuPercent: 3.1, memoryMB: 256, runtimeSeconds: 1800 },
+        ],
+      },
+    ],
+  };
 }
 
 const mockSkills: SkillItem[] = [

--- a/frontend/src/api/mock.ts
+++ b/frontend/src/api/mock.ts
@@ -1153,24 +1153,24 @@ export function mockGetResources(): ResourcesResponse {
   return {
     items: [
       {
-        environmentId: 'env-localhost',
-        environmentName: 'Localhost',
+        environment_id: 'env-localhost',
+        environment_name: 'Localhost',
         timestamp: new Date().toISOString(),
         status: 'ok',
         gpus: [
           {
             index: 0,
             name: 'NVIDIA GeForce RTX 4090',
-            utilizationPercent: 45.0,
-            memoryUsedMB: 8192,
-            memoryTotalMB: 24576,
+            utilization_percent: 45.0,
+            memory_used_mb: 8192,
+            memory_total_mb: 24576,
           },
         ],
-        cpu: { percent: 23.5, coreCount: 32 },
-        memory: { usedMB: 16384, totalMB: 65536, percent: 25.0 },
-        ainrfProcesses: [
-          { pid: 12345, name: 'ainrf', cpuPercent: 5.2, memoryMB: 512, runtimeSeconds: 3600 },
-          { pid: 12346, name: 'python', cpuPercent: 3.1, memoryMB: 256, runtimeSeconds: 1800 },
+        cpu: { percent: 23.5, core_count: 32 },
+        memory: { used_mb: 16384, total_mb: 65536, percent: 25.0 },
+        ainrf_processes: [
+          { pid: 12345, name: 'ainrf', cpu_percent: 5.2, memory_mb: 512, runtime_seconds: 3600 },
+          { pid: 12346, name: 'python', cpu_percent: 3.1, memory_mb: 256, runtime_seconds: 1800 },
         ],
       },
     ],

--- a/frontend/src/components/common/Layout.tsx
+++ b/frontend/src/components/common/Layout.tsx
@@ -1,4 +1,5 @@
 import {
+  Activity,
   Boxes,
   ChevronLeft,
   ChevronRight,
@@ -91,6 +92,12 @@ function Layout({ children, edgeToEdge = false }: Props) {
       to: '/environments',
       description: t('navigation.environments.description'),
       icon: Boxes,
+    },
+    {
+      label: t('navigation.resources.label'),
+      to: '/resources',
+      description: t('navigation.resources.description'),
+      icon: Activity,
     },
     {
       label: t('navigation.settings.label'),

--- a/frontend/src/components/resources/AinrfProcessCard.tsx
+++ b/frontend/src/components/resources/AinrfProcessCard.tsx
@@ -3,7 +3,7 @@ import { useT } from '../../i18n';
 
 interface AinrfProcessCardProps {
   processes: ProcessInfo[];
-  environmentName: string;
+  environment_name: string;
 }
 
 function formatRuntime(seconds: number): string {
@@ -19,13 +19,13 @@ function formatRuntime(seconds: number): string {
   return `${secs}s`;
 }
 
-export default function AinrfProcessCard({ processes, environmentName }: AinrfProcessCardProps) {
+export default function AinrfProcessCard({ processes, environment_name }: AinrfProcessCardProps) {
   const t = useT();
 
   return (
     <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5">
       <h3 className="mb-4 text-sm font-semibold">
-        {t('pages.resources.processCard.title')} — {environmentName}
+        {t('pages.resources.processCard.title')} — {environment_name}
       </h3>
 
       {processes.length === 0 ? (

--- a/frontend/src/components/resources/AinrfProcessCard.tsx
+++ b/frontend/src/components/resources/AinrfProcessCard.tsx
@@ -1,0 +1,61 @@
+import type { ProcessInfo } from '../../types';
+import { useT } from '../../i18n';
+
+interface AinrfProcessCardProps {
+  processes: ProcessInfo[];
+  environmentName: string;
+}
+
+function formatRuntime(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = seconds % 60;
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${secs}s`;
+  }
+  return `${secs}s`;
+}
+
+export default function AinrfProcessCard({ processes, environmentName }: AinrfProcessCardProps) {
+  const t = useT();
+
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5">
+      <h3 className="mb-4 text-sm font-semibold">
+        {t('pages.resources.processCard.title')} — {environmentName}
+      </h3>
+
+      {processes.length === 0 ? (
+        <p className="text-sm text-[var(--text-tertiary)]">{t('pages.resources.processCard.empty')}</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-xs">
+            <thead>
+              <tr className="border-b border-[var(--border)] text-[var(--text-tertiary)]">
+                <th className="pb-2 pr-4 font-medium">{t('pages.resources.processCard.columns.pid')}</th>
+                <th className="pb-2 pr-4 font-medium">{t('pages.resources.processCard.columns.name')}</th>
+                <th className="pb-2 pr-4 font-medium">{t('pages.resources.processCard.columns.cpu')}</th>
+                <th className="pb-2 pr-4 font-medium">{t('pages.resources.processCard.columns.memory')}</th>
+                <th className="pb-2 font-medium">{t('pages.resources.processCard.columns.runtime')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {processes.map((proc) => (
+                <tr key={proc.pid} className="border-b border-[var(--border)]/50 last:border-0">
+                  <td className="py-2 pr-4 font-mono">{proc.pid}</td>
+                  <td className="py-2 pr-4">{proc.name}</td>
+                  <td className="py-2 pr-4">{proc.cpuPercent.toFixed(1)}%</td>
+                  <td className="py-2 pr-4">{proc.memoryMB} MB</td>
+                  <td className="py-2">{formatRuntime(proc.runtimeSeconds)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/resources/AinrfProcessCard.tsx
+++ b/frontend/src/components/resources/AinrfProcessCard.tsx
@@ -43,7 +43,7 @@ export default function AinrfProcessCard({ processes, environmentName }: AinrfPr
               </tr>
             </thead>
             <tbody>
-              {processes.map((proc) => (
+              {[...processes].sort((a, b) => b.cpuPercent - a.cpuPercent).map((proc) => (
                 <tr key={proc.pid} className="border-b border-[var(--border)]/50 last:border-0">
                   <td className="py-2 pr-4 font-mono">{proc.pid}</td>
                   <td className="py-2 pr-4">{proc.name}</td>

--- a/frontend/src/components/resources/AinrfProcessCard.tsx
+++ b/frontend/src/components/resources/AinrfProcessCard.tsx
@@ -43,13 +43,13 @@ export default function AinrfProcessCard({ processes, environmentName }: AinrfPr
               </tr>
             </thead>
             <tbody>
-              {[...processes].sort((a, b) => b.cpuPercent - a.cpuPercent).map((proc) => (
+              {[...processes].sort((a, b) => b.cpu_percent - a.cpu_percent).map((proc) => (
                 <tr key={proc.pid} className="border-b border-[var(--border)]/50 last:border-0">
                   <td className="py-2 pr-4 font-mono">{proc.pid}</td>
                   <td className="py-2 pr-4">{proc.name}</td>
-                  <td className="py-2 pr-4">{proc.cpuPercent.toFixed(1)}%</td>
-                  <td className="py-2 pr-4">{proc.memoryMB} MB</td>
-                  <td className="py-2">{formatRuntime(proc.runtimeSeconds)}</td>
+                  <td className="py-2 pr-4">{proc.cpu_percent.toFixed(1)}%</td>
+                  <td className="py-2 pr-4">{proc.memory_mb} MB</td>
+                  <td className="py-2">{formatRuntime(proc.runtime_seconds)}</td>
                 </tr>
               ))}
             </tbody>

--- a/frontend/src/components/resources/CpuRing.tsx
+++ b/frontend/src/components/resources/CpuRing.tsx
@@ -1,6 +1,6 @@
 interface CpuRingProps {
   percent: number;
-  coreCount: number;
+  core_count: number;
 }
 
 function getColor(percent: number): string {
@@ -9,7 +9,7 @@ function getColor(percent: number): string {
   return '#ef4444';
 }
 
-export default function CpuRing({ percent, coreCount }: CpuRingProps) {
+export default function CpuRing({ percent, core_count }: CpuRingProps) {
   const radius = 36;
   const circumference = 2 * Math.PI * radius;
   const offset = circumference - (Math.min(percent, 100) / 100) * circumference;
@@ -46,7 +46,7 @@ export default function CpuRing({ percent, coreCount }: CpuRingProps) {
       </div>
       <div>
         <p className="text-xs text-[var(--text-tertiary)]">CPU Usage</p>
-        <p className="text-sm font-medium">{coreCount} cores</p>
+        <p className="text-sm font-medium">{core_count} cores</p>
       </div>
     </div>
   );

--- a/frontend/src/components/resources/CpuRing.tsx
+++ b/frontend/src/components/resources/CpuRing.tsx
@@ -1,0 +1,53 @@
+interface CpuRingProps {
+  percent: number;
+  coreCount: number;
+}
+
+function getColor(percent: number): string {
+  if (percent < 50) return '#10b981';
+  if (percent < 80) return '#f59e0b';
+  return '#ef4444';
+}
+
+export default function CpuRing({ percent, coreCount }: CpuRingProps) {
+  const radius = 36;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (Math.min(percent, 100) / 100) * circumference;
+  const color = getColor(percent);
+
+  return (
+    <div className="flex items-center gap-4">
+      <div className="relative h-20 w-20">
+        <svg className="h-full w-full -rotate-90" viewBox="0 0 80 80">
+          <circle
+            cx="40"
+            cy="40"
+            r={radius}
+            fill="none"
+            stroke="var(--bg-tertiary)"
+            strokeWidth="8"
+          />
+          <circle
+            cx="40"
+            cy="40"
+            r={radius}
+            fill="none"
+            stroke={color}
+            strokeWidth="8"
+            strokeLinecap="round"
+            strokeDasharray={circumference}
+            strokeDashoffset={offset}
+            className="transition-all duration-500"
+          />
+        </svg>
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <span className="text-lg font-semibold leading-none">{Math.round(percent)}%</span>
+        </div>
+      </div>
+      <div>
+        <p className="text-xs text-[var(--text-tertiary)]">CPU Usage</p>
+        <p className="text-sm font-medium">{coreCount} cores</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/resources/GpuBar.tsx
+++ b/frontend/src/components/resources/GpuBar.tsx
@@ -1,0 +1,47 @@
+import type { GpuInfo } from '../../types';
+
+function formatMB(mb: number): string {
+  if (mb >= 1024) {
+    return `${(mb / 1024).toFixed(1)} GB`;
+  }
+  return `${mb} MB`;
+}
+
+function getBarColor(percent: number): string {
+  if (percent < 50) return 'bg-emerald-500';
+  if (percent < 80) return 'bg-amber-500';
+  return 'bg-red-500';
+}
+
+interface GpuBarProps {
+  gpus: GpuInfo[];
+}
+
+export default function GpuBar({ gpus }: GpuBarProps) {
+  if (gpus.length === 0) {
+    return <p className="text-sm text-[var(--text-tertiary)]">No GPU detected</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {gpus.map((gpu) => (
+        <div key={gpu.index} className="space-y-1">
+          <div className="flex items-center justify-between text-xs">
+            <span className="font-medium text-[var(--foreground)]">
+              GPU {gpu.index}: {gpu.name}
+            </span>
+            <span className="text-[var(--text-tertiary)]">
+              {gpu.utilizationPercent}% | {formatMB(gpu.memoryUsedMB)} / {formatMB(gpu.memoryTotalMB)}
+            </span>
+          </div>
+          <div className="h-2 w-full overflow-hidden rounded-full bg-[var(--bg-tertiary)]">
+            <div
+              className={`h-full rounded-full transition-all duration-500 ${getBarColor(gpu.utilizationPercent)}`}
+              style={{ width: `${Math.min(gpu.utilizationPercent, 100)}%` }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/resources/GpuBar.tsx
+++ b/frontend/src/components/resources/GpuBar.tsx
@@ -31,13 +31,13 @@ export default function GpuBar({ gpus }: GpuBarProps) {
               GPU {gpu.index}: {gpu.name}
             </span>
             <span className="text-[var(--text-tertiary)]">
-              {gpu.utilizationPercent}% | {formatMB(gpu.memoryUsedMB)} / {formatMB(gpu.memoryTotalMB)}
+              {gpu.utilization_percent}% | {formatMB(gpu.memory_used_mb)} / {formatMB(gpu.memory_total_mb)}
             </span>
           </div>
           <div className="h-2 w-full overflow-hidden rounded-full bg-[var(--bg-tertiary)]">
             <div
-              className={`h-full rounded-full transition-all duration-500 ${getBarColor(gpu.utilizationPercent)}`}
-              style={{ width: `${Math.min(gpu.utilizationPercent, 100)}%` }}
+              className={`h-full rounded-full transition-all duration-500 ${getBarColor(gpu.utilization_percent)}`}
+              style={{ width: `${Math.min(gpu.utilization_percent, 100)}%` }}
             />
           </div>
         </div>

--- a/frontend/src/components/resources/MemoryBar.tsx
+++ b/frontend/src/components/resources/MemoryBar.tsx
@@ -6,19 +6,19 @@ function formatMB(mb: number): string {
 }
 
 interface MemoryBarProps {
-  usedMB: number;
-  totalMB: number;
+  used_mb: number;
+  total_mb: number;
 }
 
-export default function MemoryBar({ usedMB, totalMB }: MemoryBarProps) {
-  const percent = totalMB > 0 ? Math.round((usedMB / totalMB) * 100) : 0;
+export default function MemoryBar({ used_mb, total_mb }: MemoryBarProps) {
+  const percent = total_mb > 0 ? Math.round((used_mb / total_mb) * 100) : 0;
 
   return (
     <div className="space-y-1">
       <div className="flex items-center justify-between text-xs">
         <span className="font-medium">Memory</span>
         <span className="text-[var(--text-tertiary)]">
-          {formatMB(usedMB)} / {formatMB(totalMB)} ({percent}%)
+          {formatMB(used_mb)} / {formatMB(total_mb)} ({percent}%)
         </span>
       </div>
       <div className="h-2 w-full overflow-hidden rounded-full bg-[var(--bg-tertiary)]">

--- a/frontend/src/components/resources/MemoryBar.tsx
+++ b/frontend/src/components/resources/MemoryBar.tsx
@@ -1,0 +1,32 @@
+function formatMB(mb: number): string {
+  if (mb >= 1024) {
+    return `${(mb / 1024).toFixed(1)} GB`;
+  }
+  return `${mb} MB`;
+}
+
+interface MemoryBarProps {
+  usedMB: number;
+  totalMB: number;
+}
+
+export default function MemoryBar({ usedMB, totalMB }: MemoryBarProps) {
+  const percent = totalMB > 0 ? Math.round((usedMB / totalMB) * 100) : 0;
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-xs">
+        <span className="font-medium">Memory</span>
+        <span className="text-[var(--text-tertiary)]">
+          {formatMB(usedMB)} / {formatMB(totalMB)} ({percent}%)
+        </span>
+      </div>
+      <div className="h-2 w-full overflow-hidden rounded-full bg-[var(--bg-tertiary)]">
+        <div
+          className="h-full rounded-full bg-blue-500 transition-all duration-500"
+          style={{ width: `${Math.min(percent, 100)}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/resources/SystemResourceCard.tsx
+++ b/frontend/src/components/resources/SystemResourceCard.tsx
@@ -41,14 +41,14 @@ export default function SystemResourceCard({ snapshot }: SystemResourceCardProps
           <p className="mb-2 text-xs font-medium text-[var(--text-secondary)]">
             {t('pages.resources.systemCard.cpuTitle')}
           </p>
-          <CpuRing percent={snapshot.cpu.percent} coreCount={snapshot.cpu.core_count} />
+          <CpuRing percent={snapshot.cpu.percent} core_count={snapshot.cpu.core_count} />
         </div>
 
         <div>
           <p className="mb-2 text-xs font-medium text-[var(--text-secondary)]">
             {t('pages.resources.systemCard.memoryTitle')}
           </p>
-          <MemoryBar usedMB={snapshot.memory.used_mb} totalMB={snapshot.memory.total_mb} />
+          <MemoryBar used_mb={snapshot.memory.used_mb} total_mb={snapshot.memory.total_mb} />
         </div>
       </div>
     </div>

--- a/frontend/src/components/resources/SystemResourceCard.tsx
+++ b/frontend/src/components/resources/SystemResourceCard.tsx
@@ -1,0 +1,56 @@
+import type { ResourceSnapshot } from '../../types';
+import { useT } from '../../i18n';
+import GpuBar from './GpuBar';
+import CpuRing from './CpuRing';
+import MemoryBar from './MemoryBar';
+
+interface SystemResourceCardProps {
+  snapshot: ResourceSnapshot;
+}
+
+function StatusDot({ status }: { status: ResourceSnapshot['status'] }) {
+  const color =
+    status === 'ok' ? 'bg-emerald-500' : status === 'degraded' ? 'bg-amber-500' : 'bg-red-500';
+  return <span className={`inline-block h-2 w-2 rounded-full ${color}`} />;
+}
+
+export default function SystemResourceCard({ snapshot }: SystemResourceCardProps) {
+  const t = useT();
+
+  return (
+    <div className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-5">
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <StatusDot status={snapshot.status} />
+          <h3 className="text-sm font-semibold">{snapshot.environmentName}</h3>
+        </div>
+        <span className="text-xs text-[var(--text-tertiary)]">
+          {new Date(snapshot.timestamp).toLocaleTimeString()}
+        </span>
+      </div>
+
+      <div className="space-y-5">
+        <div>
+          <p className="mb-2 text-xs font-medium text-[var(--text-secondary)]">
+            {t('pages.resources.systemCard.gpuTitle')}
+          </p>
+          <GpuBar gpus={snapshot.gpus} />
+        </div>
+
+        <div>
+          <p className="mb-2 text-xs font-medium text-[var(--text-secondary)]">
+            {t('pages.resources.systemCard.cpuTitle')}
+          </p>
+          <CpuRing percent={snapshot.cpu.percent} coreCount={snapshot.cpu.coreCount} />
+        </div>
+
+        <div>
+          <p className="mb-2 text-xs font-medium text-[var(--text-secondary)]">
+            {t('pages.resources.systemCard.memoryTitle')}
+          </p>
+          <MemoryBar usedMB={snapshot.memory.usedMB} totalMB={snapshot.memory.totalMB} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/resources/SystemResourceCard.tsx
+++ b/frontend/src/components/resources/SystemResourceCard.tsx
@@ -22,7 +22,7 @@ export default function SystemResourceCard({ snapshot }: SystemResourceCardProps
       <div className="mb-4 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <StatusDot status={snapshot.status} />
-          <h3 className="text-sm font-semibold">{snapshot.environmentName}</h3>
+          <h3 className="text-sm font-semibold">{snapshot.environment_name}</h3>
         </div>
         <span className="text-xs text-[var(--text-tertiary)]">
           {new Date(snapshot.timestamp).toLocaleTimeString()}
@@ -41,14 +41,14 @@ export default function SystemResourceCard({ snapshot }: SystemResourceCardProps
           <p className="mb-2 text-xs font-medium text-[var(--text-secondary)]">
             {t('pages.resources.systemCard.cpuTitle')}
           </p>
-          <CpuRing percent={snapshot.cpu.percent} coreCount={snapshot.cpu.coreCount} />
+          <CpuRing percent={snapshot.cpu.percent} coreCount={snapshot.cpu.core_count} />
         </div>
 
         <div>
           <p className="mb-2 text-xs font-medium text-[var(--text-secondary)]">
             {t('pages.resources.systemCard.memoryTitle')}
           </p>
-          <MemoryBar usedMB={snapshot.memory.usedMB} totalMB={snapshot.memory.totalMB} />
+          <MemoryBar usedMB={snapshot.memory.used_mb} totalMB={snapshot.memory.total_mb} />
         </div>
       </div>
     </div>

--- a/frontend/src/components/resources/index.ts
+++ b/frontend/src/components/resources/index.ts
@@ -1,0 +1,5 @@
+export { default as GpuBar } from './GpuBar';
+export { default as CpuRing } from './CpuRing';
+export { default as MemoryBar } from './MemoryBar';
+export { default as SystemResourceCard } from './SystemResourceCard';
+export { default as AinrfProcessCard } from './AinrfProcessCard';

--- a/frontend/src/i18n/messages.ts
+++ b/frontend/src/i18n/messages.ts
@@ -84,6 +84,10 @@ export const messages = {
         label: 'Containers',
         description: 'Runtime environments and container status',
       },
+      resources: {
+        label: 'Resources',
+        description: 'System resource monitoring and usage',
+      },
       settings: {
         label: 'Settings',
         description: 'Runtime and WebUI preferences',
@@ -407,6 +411,36 @@ export const messages = {
         updateProjectReference: 'Update project binding',
         attachProjectReference: 'Attach to project',
       },
+      resources: {
+        eyebrow: 'RESOURCES',
+        title: 'Resource Monitor',
+        description: 'Real-time system resource usage across all environments.',
+        loading: 'Loading resources...',
+        noData: 'No resource data available yet.',
+        systemCard: {
+          title: 'System Resources',
+          gpuTitle: 'GPU',
+          cpuTitle: 'CPU',
+          memoryTitle: 'Memory',
+          noGpu: 'No GPU detected',
+        },
+        processCard: {
+          title: 'AINRF Processes',
+          empty: 'No AINRF processes detected',
+          columns: {
+            pid: 'PID',
+            name: 'Name',
+            cpu: 'CPU%',
+            memory: 'Memory',
+            runtime: 'Runtime',
+          },
+        },
+        status: {
+          ok: 'Healthy',
+          degraded: 'Degraded',
+          unavailable: 'Unavailable',
+        },
+      },
     },
     components: {
       healthStatusBar: {
@@ -616,6 +650,10 @@ export const messages = {
       environments: {
         label: '容器',
         description: '运行环境与容器状态',
+      },
+      resources: {
+        label: '资源监控',
+        description: '系统资源占用与使用情况',
       },
       settings: {
         label: '设置',
@@ -924,6 +962,36 @@ export const messages = {
         projectReferenceSaving: '正在保存绑定…',
         updateProjectReference: '更新项目绑定',
         attachProjectReference: '绑定到项目',
+      },
+      resources: {
+        eyebrow: '资源监控',
+        title: '资源监控',
+        description: '所有环境的实时系统资源占用情况。',
+        loading: '正在加载资源数据...',
+        noData: '暂无资源数据。',
+        systemCard: {
+          title: '系统资源',
+          gpuTitle: 'GPU',
+          cpuTitle: 'CPU',
+          memoryTitle: '内存',
+          noGpu: '未检测到 GPU',
+        },
+        processCard: {
+          title: 'AINRF 进程',
+          empty: '未检测到 AINRF 进程',
+          columns: {
+            pid: 'PID',
+            name: '进程名',
+            cpu: 'CPU%',
+            memory: '内存',
+            runtime: '运行时间',
+          },
+        },
+        status: {
+          ok: '正常',
+          degraded: '降级',
+          unavailable: '不可用',
+        },
       },
     },
     components: {

--- a/frontend/src/pages/ResourcesPage.test.tsx
+++ b/frontend/src/pages/ResourcesPage.test.tsx
@@ -1,0 +1,135 @@
+import { screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ResourcesPage from './ResourcesPage';
+import type { ResourcesResponse } from '../types';
+import { renderWithProviders } from '../test/render';
+import { getResources } from '../api';
+
+vi.mock('../api', () => ({
+  getResources: vi.fn(),
+}));
+
+const mockGetResources = vi.mocked(getResources);
+
+const mockResponse: ResourcesResponse = {
+  items: [
+    {
+      environmentId: 'env-localhost',
+      environmentName: 'Localhost',
+      timestamp: '2026-05-06T12:00:00Z',
+      status: 'ok',
+      gpus: [
+        {
+          index: 0,
+          name: 'NVIDIA GeForce RTX 4090',
+          utilizationPercent: 45.0,
+          memoryUsedMB: 8192,
+          memoryTotalMB: 24576,
+        },
+      ],
+      cpu: {
+        percent: 23.5,
+        coreCount: 32,
+      },
+      memory: {
+        usedMB: 16384,
+        totalMB: 65536,
+        percent: 25.0,
+      },
+      ainrfProcesses: [
+        {
+          pid: 12345,
+          name: 'ainrf',
+          cpuPercent: 5.2,
+          memoryMB: 512,
+          runtimeSeconds: 3600,
+        },
+      ],
+    },
+  ],
+};
+
+beforeEach(() => {
+  mockGetResources.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ResourcesPage', () => {
+  it('renders page title in the current language and eyebrow in the alternate language', async () => {
+    mockGetResources.mockResolvedValue({ items: [] });
+    const { unmount } = renderWithProviders(<ResourcesPage />, {
+      locale: 'en',
+    });
+
+    expect(await screen.findByRole('heading', { name: 'Resource Monitor' })).toBeInTheDocument();
+    expect(screen.getByText('RESOURCES')).toBeInTheDocument();
+
+    unmount();
+    mockGetResources.mockResolvedValue({ items: [] });
+    renderWithProviders(<ResourcesPage />, {
+      locale: 'zh',
+    });
+
+    expect(await screen.findByRole('heading', { name: '资源监控' })).toBeInTheDocument();
+    // In Chinese, eyebrow and title are both "资源监控", so use getAllByText
+    expect(screen.getAllByText('资源监控').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders resource data for multiple environments', async () => {
+    mockGetResources.mockResolvedValue(mockResponse);
+
+    renderWithProviders(<ResourcesPage />);
+
+    expect(await screen.findByText('Localhost')).toBeInTheDocument();
+    expect(screen.getByText(/NVIDIA GeForce RTX 4090/)).toBeInTheDocument();
+    expect(screen.getByText('45% | 8.0 GB / 24.0 GB')).toBeInTheDocument();
+    expect(screen.getByText('32 cores')).toBeInTheDocument();
+    expect(screen.getByText('16.0 GB / 64.0 GB (25%)')).toBeInTheDocument();
+    expect(screen.getByText('12345')).toBeInTheDocument();
+    expect(screen.getByText('ainrf')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no resource data is available', async () => {
+    mockGetResources.mockResolvedValue({ items: [] });
+
+    renderWithProviders(<ResourcesPage />);
+
+    expect(await screen.findByText('No resource data available yet.')).toBeInTheDocument();
+  });
+
+  it('renders degraded status with yellow indicator', async () => {
+    const degradedResponse: ResourcesResponse = {
+      items: [
+        {
+          ...mockResponse.items[0],
+          status: 'degraded',
+        },
+      ],
+    };
+    mockGetResources.mockResolvedValue(degradedResponse);
+
+    renderWithProviders(<ResourcesPage />);
+
+    expect(await screen.findByText('Localhost')).toBeInTheDocument();
+  });
+
+  it('hides GPU section when no GPUs are present', async () => {
+    const noGpuResponse: ResourcesResponse = {
+      items: [
+        {
+          ...mockResponse.items[0],
+          gpus: [],
+        },
+      ],
+    };
+    mockGetResources.mockResolvedValue(noGpuResponse);
+
+    renderWithProviders(<ResourcesPage />);
+
+    expect(await screen.findByText('Localhost')).toBeInTheDocument();
+    expect(screen.getByText('No GPU detected')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ResourcesPage.test.tsx
+++ b/frontend/src/pages/ResourcesPage.test.tsx
@@ -14,35 +14,35 @@ const mockGetResources = vi.mocked(getResources);
 const mockResponse: ResourcesResponse = {
   items: [
     {
-      environmentId: 'env-localhost',
-      environmentName: 'Localhost',
+      environment_id: 'env-localhost',
+      environment_name: 'Localhost',
       timestamp: '2026-05-06T12:00:00Z',
       status: 'ok',
       gpus: [
         {
           index: 0,
           name: 'NVIDIA GeForce RTX 4090',
-          utilizationPercent: 45.0,
-          memoryUsedMB: 8192,
-          memoryTotalMB: 24576,
+          utilization_percent: 45.0,
+          memory_used_mb: 8192,
+          memory_total_mb: 24576,
         },
       ],
       cpu: {
         percent: 23.5,
-        coreCount: 32,
+        core_count: 32,
       },
       memory: {
-        usedMB: 16384,
-        totalMB: 65536,
+        used_mb: 16384,
+        total_mb: 65536,
         percent: 25.0,
       },
-      ainrfProcesses: [
+      ainrf_processes: [
         {
           pid: 12345,
           name: 'ainrf',
-          cpuPercent: 5.2,
-          memoryMB: 512,
-          runtimeSeconds: 3600,
+          cpu_percent: 5.2,
+          memory_mb: 512,
+          runtime_seconds: 3600,
         },
       ],
     },

--- a/frontend/src/pages/ResourcesPage.tsx
+++ b/frontend/src/pages/ResourcesPage.tsx
@@ -40,7 +40,7 @@ export default function ResourcesPage() {
             <SystemResourceCard snapshot={snapshot} />
             <AinrfProcessCard
               processes={snapshot.ainrf_processes}
-              environmentName={snapshot.environment_name}
+              environment_name={snapshot.environment_name}
             />
           </div>
         ))}

--- a/frontend/src/pages/ResourcesPage.tsx
+++ b/frontend/src/pages/ResourcesPage.tsx
@@ -36,11 +36,11 @@ export default function ResourcesPage() {
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         {snapshots.map((snapshot) => (
-          <div key={snapshot.environmentId} className="space-y-4">
+          <div key={snapshot.environment_id} className="space-y-4">
             <SystemResourceCard snapshot={snapshot} />
             <AinrfProcessCard
-              processes={snapshot.ainrfProcesses}
-              environmentName={snapshot.environmentName}
+              processes={snapshot.ainrf_processes}
+              environmentName={snapshot.environment_name}
             />
           </div>
         ))}

--- a/frontend/src/pages/ResourcesPage.tsx
+++ b/frontend/src/pages/ResourcesPage.tsx
@@ -1,0 +1,50 @@
+import { useQuery } from '@tanstack/react-query';
+import { getResources } from '../api';
+import { SystemResourceCard, AinrfProcessCard } from '../components/resources';
+import { useT } from '../i18n';
+
+export default function ResourcesPage() {
+  const t = useT();
+  const resourcesQuery = useQuery({
+    queryKey: ['resources'],
+    queryFn: getResources,
+    refetchInterval: 5000,
+    staleTime: 4000,
+  });
+
+  const snapshots = resourcesQuery.data?.items ?? [];
+
+  return (
+    <div className="space-y-8">
+      <div className="space-y-1">
+        <p className="text-xs font-medium uppercase tracking-wider text-[var(--text-tertiary)]">
+          {t('pages.resources.eyebrow')}
+        </p>
+        <h1 className="text-2xl font-semibold tracking-tight">{t('pages.resources.title')}</h1>
+        <p className="text-sm leading-relaxed text-[var(--text-secondary)]">
+          {t('pages.resources.description')}
+        </p>
+      </div>
+
+      {resourcesQuery.isLoading && snapshots.length === 0 && (
+        <p className="text-sm text-[var(--text-tertiary)]">{t('pages.resources.loading')}</p>
+      )}
+
+      {snapshots.length === 0 && !resourcesQuery.isLoading && (
+        <p className="text-sm text-[var(--text-tertiary)]">{t('pages.resources.noData')}</p>
+      )}
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        {snapshots.map((snapshot) => (
+          <div key={snapshot.environmentId} className="space-y-4">
+            <SystemResourceCard snapshot={snapshot} />
+            <AinrfProcessCard
+              processes={snapshot.ainrfProcesses}
+              environmentName={snapshot.environmentName}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -519,39 +519,39 @@ export interface SkillImportResponse {
 export interface GpuInfo {
   index: number;
   name: string;
-  utilizationPercent: number;
-  memoryUsedMB: number;
-  memoryTotalMB: number;
+  utilization_percent: number;
+  memory_used_mb: number;
+  memory_total_mb: number;
 }
 
 export interface CpuInfo {
   percent: number;
-  coreCount: number;
+  core_count: number;
 }
 
 export interface MemoryInfo {
-  usedMB: number;
-  totalMB: number;
+  used_mb: number;
+  total_mb: number;
   percent: number;
 }
 
 export interface ProcessInfo {
   pid: number;
   name: string;
-  cpuPercent: number;
-  memoryMB: number;
-  runtimeSeconds: number;
+  cpu_percent: number;
+  memory_mb: number;
+  runtime_seconds: number;
 }
 
 export interface ResourceSnapshot {
-  environmentId: string;
-  environmentName: string;
+  environment_id: string;
+  environment_name: string;
   timestamp: string;
   status: "ok" | "degraded" | "unavailable";
   gpus: GpuInfo[];
   cpu: CpuInfo;
   memory: MemoryInfo;
-  ainrfProcesses: ProcessInfo[];
+  ainrf_processes: ProcessInfo[];
 }
 
 export interface ResourcesResponse {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -515,3 +515,45 @@ export interface SkillImportResponse {
   label: string;
   path: string;
 }
+
+export interface GpuInfo {
+  index: number;
+  name: string;
+  utilizationPercent: number;
+  memoryUsedMB: number;
+  memoryTotalMB: number;
+}
+
+export interface CpuInfo {
+  percent: number;
+  coreCount: number;
+}
+
+export interface MemoryInfo {
+  usedMB: number;
+  totalMB: number;
+  percent: number;
+}
+
+export interface ProcessInfo {
+  pid: number;
+  name: string;
+  cpuPercent: number;
+  memoryMB: number;
+  runtimeSeconds: number;
+}
+
+export interface ResourceSnapshot {
+  environmentId: string;
+  environmentName: string;
+  timestamp: string;
+  status: "ok" | "degraded" | "unavailable";
+  gpus: GpuInfo[];
+  cpu: CpuInfo;
+  memory: MemoryInfo;
+  ainrfProcesses: ProcessInfo[];
+}
+
+export interface ResourcesResponse {
+  items: ResourceSnapshot[];
+}

--- a/src/ainrf/api/app.py
+++ b/src/ainrf/api/app.py
@@ -13,10 +13,12 @@ from ainrf.api.routes.environments import router as environments_router
 from ainrf.api.routes.files import router as files_router
 from ainrf.api.routes.health import router as health_router
 from ainrf.api.routes.projects import router as projects_router
+from ainrf.api.routes.resources import router as resources_router
 from ainrf.api.routes.skills import router as skills_router
 from ainrf.api.routes.tasks import router as tasks_router
 from ainrf.api.routes.terminal import router as terminal_router
 from ainrf.api.routes.workspaces import router as workspaces_router
+from ainrf.monitor.service import ResourceMonitorService
 from ainrf.code_server import CodeServerSupervisor
 from ainrf.files import FileBrowserService
 from ainrf.environments import InMemoryEnvironmentService
@@ -45,6 +47,7 @@ ROUTERS: tuple[APIRouter, ...] = (
     terminal_router,
     tasks_router,
     code_router,
+    resources_router,
 )
 
 
@@ -64,6 +67,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     )
     app.state.code_server_manager = manager
     app.state.code_server_supervisor = manager
+    resource_monitor_service = ResourceMonitorService(environment_service)
+    app.state.resource_monitor_service = resource_monitor_service
+    await resource_monitor_service.start()
     try:
         await _run_sync_in_lifespan(project_service.initialize)
         await _run_sync_in_lifespan(workspace_service.initialize)
@@ -77,6 +83,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     finally:
         await _run_sync_in_lifespan(terminal_attachment_broker.shutdown)
         await manager.stop()
+        await resource_monitor_service.stop()
 
 
 def create_app(config: ApiConfig | None = None) -> FastAPI:

--- a/src/ainrf/api/routes/__init__.py
+++ b/src/ainrf/api/routes/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from . import environments, health, terminal
+from . import environments, health, resources, terminal
 
-__all__ = ["environments", "health", "terminal"]
+__all__ = ["environments", "health", "resources", "terminal"]

--- a/src/ainrf/api/routes/resources.py
+++ b/src/ainrf/api/routes/resources.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+from ainrf.monitor.models import ResourcesResponse
+
+router = APIRouter(prefix="/resources", tags=["resources"])
+
+
+@router.get("", response_model=ResourcesResponse)
+async def get_resources(request: Request) -> ResourcesResponse:
+    monitor_service = getattr(request.app.state, "resource_monitor_service", None)
+    if monitor_service is None:
+        return ResourcesResponse(items=[])
+
+    snapshots = monitor_service.get_snapshots()
+    return ResourcesResponse(items=list(snapshots.values()))

--- a/src/ainrf/api/schemas.py
+++ b/src/ainrf/api/schemas.py
@@ -691,3 +691,8 @@ class FileUploadResponse(BaseModel):
 
     path: str
     size: int
+
+
+class ResourcesResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    items: list[dict[str, object]] = Field(default_factory=list)

--- a/src/ainrf/api/schemas.py
+++ b/src/ainrf/api/schemas.py
@@ -693,6 +693,4 @@ class FileUploadResponse(BaseModel):
     size: int
 
 
-class ResourcesResponse(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-    items: list[dict[str, object]] = Field(default_factory=list)
+

--- a/src/ainrf/monitor/collectors.py
+++ b/src/ainrf/monitor/collectors.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from ainrf.monitor.models import CpuInfo, GpuInfo, MemoryInfo, ResourceSnapshot
+from ainrf.monitor.process_tree import ProcessTreeFilter, RawProcess
+
+if TYPE_CHECKING:
+    from ainrf.execution.ssh import SSHExecutor
+
+
+def parse_nvidia_smi_csv(stdout: str) -> list[GpuInfo]:
+    lines = [line.strip() for line in stdout.strip().split("\n") if line.strip()]
+    if not lines:
+        return []
+
+    if "name" in lines[0].lower() or "index" in lines[0].lower():
+        lines = lines[1:]
+
+    gpus: list[GpuInfo] = []
+    for line in lines:
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) < 5:
+            continue
+        try:
+            gpus.append(
+                GpuInfo(
+                    index=int(parts[0]),
+                    name=parts[1],
+                    utilization_percent=float(parts[2].replace("%", "").strip()),
+                    memory_used_mb=int(parts[3].replace("MiB", "").strip()),
+                    memory_total_mb=int(parts[4].replace("MiB", "").strip()),
+                )
+            )
+        except (ValueError, IndexError):
+            continue
+    return gpus
+
+
+def parse_ps_output(stdout: str) -> list[RawProcess]:
+    lines = [line.strip() for line in stdout.strip().split("\n") if line.strip()]
+    if not lines:
+        return []
+
+    if "PID" in lines[0].upper():
+        lines = lines[1:]
+
+    processes: list[RawProcess] = []
+    for line in lines:
+        parts = line.split()
+        if len(parts) < 6:
+            continue
+        try:
+            processes.append(
+                RawProcess(
+                    pid=int(parts[0]),
+                    ppid=int(parts[1]),
+                    name=parts[2],
+                    cpu_percent=float(parts[3]),
+                    memory_mb=int(float(parts[4])),
+                    runtime_seconds=_parse_elapsed(parts[5]),
+                )
+            )
+        except (ValueError, IndexError):
+            continue
+    return processes
+
+
+def _parse_elapsed(elapsed: str) -> int:
+    parts = elapsed.split("-")
+    if len(parts) == 2:
+        days = int(parts[0])
+        time_part = parts[1]
+    else:
+        days = 0
+        time_part = parts[0]
+
+    time_parts = time_part.split(":")
+    if len(time_parts) == 3:
+        hours, minutes, seconds = int(time_parts[0]), int(time_parts[1]), int(time_parts[2])
+    elif len(time_parts) == 2:
+        hours, minutes, seconds = 0, int(time_parts[0]), int(time_parts[1])
+    else:
+        hours, minutes, seconds = 0, 0, int(time_parts[0])
+
+    return days * 86400 + hours * 3600 + minutes * 60 + seconds
+
+
+class LocalCollector:
+    def __init__(self) -> None:
+        self._own_pid = os.getpid()
+
+    async def collect(self) -> ResourceSnapshot:
+        gpus = await self._collect_gpu()
+        processes = await self._collect_processes()
+        cpu, memory = self._extract_system_stats(processes)
+
+        filter_ = ProcessTreeFilter(root_pid=self._own_pid)
+        ainrf_processes = filter_.collect_ainrf_processes(processes)
+
+        return ResourceSnapshot(
+            environment_id="env-localhost",
+            environment_name="Localhost",
+            timestamp=datetime.now(tz=timezone.utc),
+            status="ok",
+            gpus=gpus,
+            cpu=cpu,
+            memory=memory,
+            ainrf_processes=ainrf_processes,
+        )
+
+    async def _collect_gpu(self) -> list[GpuInfo]:
+        if not shutil.which("nvidia-smi"):
+            return []
+
+        proc = await asyncio.create_subprocess_exec(
+            "nvidia-smi",
+            "--query-gpu=index,name,utilization.gpu,memory.used,memory.total",
+            "--format=csv",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=3)
+        return parse_nvidia_smi_csv(stdout.decode())
+
+    async def _collect_processes(self) -> list[RawProcess]:
+        proc = await asyncio.create_subprocess_exec(
+            "ps", "-eo", "pid,ppid,comm,pcpu,pmem,etime",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=3)
+        return parse_ps_output(stdout.decode())
+
+    def _extract_system_stats(self, processes: list[RawProcess]) -> tuple[CpuInfo, MemoryInfo]:
+        total_cpu = sum(p.cpu_percent for p in processes)
+        memory = self._read_meminfo()
+        return CpuInfo(percent=round(total_cpu, 1), core_count=os.cpu_count() or 1), memory
+
+    def _read_meminfo(self) -> MemoryInfo:
+        try:
+            with open("/proc/meminfo") as f:
+                content = f.read()
+            total_kb = 0
+            available_kb = 0
+            for line in content.split("\n"):
+                if line.startswith("MemTotal:"):
+                    total_kb = int(line.split()[1])
+                elif line.startswith("MemAvailable:"):
+                    available_kb = int(line.split()[1])
+            used_kb = total_kb - available_kb
+            total_mb = total_kb // 1024
+            used_mb = used_kb // 1024
+            percent = round((used_mb / total_mb) * 100, 1) if total_mb > 0 else 0.0
+            return MemoryInfo(used_mb=used_mb, total_mb=total_mb, percent=percent)
+        except Exception:
+            return MemoryInfo(used_mb=0, total_mb=0, percent=0.0)
+
+
+class RemoteCollector:
+    def __init__(self, executor: SSHExecutor, environment_id: str, environment_name: str) -> None:
+        self._executor = executor
+        self._environment_id = environment_id
+        self._environment_name = environment_name
+
+    async def collect(self) -> ResourceSnapshot:
+        gpus: list[GpuInfo] = []
+        processes: list[RawProcess] = []
+        status = "ok"
+
+        try:
+            gpu_result = await self._executor.run_command(
+                "nvidia-smi --query-gpu=index,name,utilization.gpu,memory.used,memory.total --format=csv",
+                timeout=3,
+            )
+            if gpu_result.exit_code == 0:
+                gpus = parse_nvidia_smi_csv(gpu_result.stdout)
+        except Exception:
+            pass
+
+        try:
+            ps_result = await self._executor.run_command(
+                "ps -eo pid,ppid,comm,pcpu,pmem,etime",
+                timeout=3,
+            )
+            if ps_result.exit_code == 0:
+                processes = parse_ps_output(ps_result.stdout)
+        except Exception:
+            status = "unavailable"
+
+        ainrf_processes = [p for p in processes if p.name in ProcessTreeFilter.WHITELIST]
+        ainrf_processes.sort(key=lambda p: p.cpu_percent, reverse=True)
+
+        total_cpu = sum(p.cpu_percent for p in processes)
+        memory = await self._collect_memory()
+
+        return ResourceSnapshot(
+            environment_id=self._environment_id,
+            environment_name=self._environment_name,
+            timestamp=datetime.now(tz=timezone.utc),
+            status=status,
+            gpus=gpus,
+            cpu=CpuInfo(percent=round(total_cpu, 1), core_count=1),
+            memory=memory,
+            ainrf_processes=ainrf_processes,
+        )
+
+    async def _collect_memory(self) -> MemoryInfo:
+        try:
+            result = await self._executor.run_command(
+                "free -m | awk 'NR==2{print $3,$2}'",
+                timeout=3,
+            )
+            if result.exit_code == 0:
+                parts = result.stdout.strip().split()
+                if len(parts) == 2:
+                    used_mb = int(parts[0])
+                    total_mb = int(parts[1])
+                    percent = round((used_mb / total_mb) * 100, 1) if total_mb > 0 else 0.0
+                    return MemoryInfo(used_mb=used_mb, total_mb=total_mb, percent=percent)
+        except Exception:
+            pass
+        return MemoryInfo(used_mb=0, total_mb=0, percent=0.0)

--- a/src/ainrf/monitor/collectors.py
+++ b/src/ainrf/monitor/collectors.py
@@ -42,9 +42,11 @@ def parse_nvidia_smi_csv(stdout: str) -> list[GpuInfo]:
 
 
 def parse_ps_output(stdout: str) -> list[RawProcess]:
-    """Parse ``ps -eo pid,ppid,comm,pcpu,rss,etime`` output.
+    """Parse ``ps -eo pid,ppid,pcpu,rss,etime,comm`` output.
 
-    The ``rss`` column is resident set size in **KB**; it is converted to MB here.
+    ``comm`` is placed last because it may contain spaces. We parse the first
+    five fixed columns and join the remainder as the command name. The ``rss``
+    column is resident set size in **KB**; it is converted to MB here.
     """
     lines = [line.strip() for line in stdout.strip().split("\n") if line.strip()]
     if not lines:
@@ -63,10 +65,10 @@ def parse_ps_output(stdout: str) -> list[RawProcess]:
                 RawProcess(
                     pid=int(parts[0]),
                     ppid=int(parts[1]),
-                    name=parts[2],
-                    cpu_percent=float(parts[3]),
-                    memory_mb=int(parts[4]) // 1024,  # rss is in KB → convert to MB
-                    runtime_seconds=_parse_elapsed(parts[5]),
+                    cpu_percent=float(parts[2]),
+                    memory_mb=int(parts[3]) // 1024,  # rss is in KB → convert to MB
+                    runtime_seconds=_parse_elapsed(parts[4]),
+                    name=" ".join(parts[5:]),
                 )
             )
         except (ValueError, IndexError):
@@ -133,7 +135,7 @@ class LocalCollector:
 
     async def _collect_processes(self) -> list[RawProcess]:
         proc = await asyncio.create_subprocess_exec(
-            "ps", "-eo", "pid,ppid,comm,pcpu,rss,etime",
+            "ps", "-eo", "pid,ppid,pcpu,rss,etime,comm",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -191,7 +193,7 @@ class RemoteCollector:
 
         try:
             ps_result = await self._executor.run_command(
-                "ps -eo pid,ppid,comm,pcpu,rss,etime",
+                "ps -eo pid,ppid,pcpu,rss,etime,comm",
                 timeout=3,
             )
             if ps_result.exit_code == 0:

--- a/src/ainrf/monitor/collectors.py
+++ b/src/ainrf/monitor/collectors.py
@@ -42,6 +42,10 @@ def parse_nvidia_smi_csv(stdout: str) -> list[GpuInfo]:
 
 
 def parse_ps_output(stdout: str) -> list[RawProcess]:
+    """Parse ``ps -eo pid,ppid,comm,pcpu,rss,etime`` output.
+
+    The ``rss`` column is resident set size in **KB**; it is converted to MB here.
+    """
     lines = [line.strip() for line in stdout.strip().split("\n") if line.strip()]
     if not lines:
         return []
@@ -61,7 +65,7 @@ def parse_ps_output(stdout: str) -> list[RawProcess]:
                     ppid=int(parts[1]),
                     name=parts[2],
                     cpu_percent=float(parts[3]),
-                    memory_mb=int(float(parts[4])),
+                    memory_mb=int(parts[4]) // 1024,  # rss is in KB → convert to MB
                     runtime_seconds=_parse_elapsed(parts[5]),
                 )
             )
@@ -129,7 +133,7 @@ class LocalCollector:
 
     async def _collect_processes(self) -> list[RawProcess]:
         proc = await asyncio.create_subprocess_exec(
-            "ps", "-eo", "pid,ppid,comm,pcpu,pmem,etime",
+            "ps", "-eo", "pid,ppid,comm,pcpu,rss,etime",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -137,9 +141,12 @@ class LocalCollector:
         return parse_ps_output(stdout.decode())
 
     def _extract_system_stats(self, processes: list[RawProcess]) -> tuple[CpuInfo, MemoryInfo]:
+        core_count = os.cpu_count() or 1
         total_cpu = sum(p.cpu_percent for p in processes)
+        # pcpu is percent of one CPU; dividing by core_count normalises to 0–100 % system load.
+        system_percent = round(total_cpu / core_count, 1)
         memory = self._read_meminfo()
-        return CpuInfo(percent=round(total_cpu, 1), core_count=os.cpu_count() or 1), memory
+        return CpuInfo(percent=system_percent, core_count=core_count), memory
 
     def _read_meminfo(self) -> MemoryInfo:
         try:
@@ -184,7 +191,7 @@ class RemoteCollector:
 
         try:
             ps_result = await self._executor.run_command(
-                "ps -eo pid,ppid,comm,pcpu,pmem,etime",
+                "ps -eo pid,ppid,comm,pcpu,rss,etime",
                 timeout=3,
             )
             if ps_result.exit_code == 0:
@@ -195,7 +202,9 @@ class RemoteCollector:
         ainrf_processes = [p for p in processes if p.name in ProcessTreeFilter.WHITELIST]
         ainrf_processes.sort(key=lambda p: p.cpu_percent, reverse=True)
 
+        core_count = await self._collect_core_count()
         total_cpu = sum(p.cpu_percent for p in processes)
+        system_percent = round(total_cpu / core_count, 1)
         memory = await self._collect_memory()
 
         return ResourceSnapshot(
@@ -204,10 +213,22 @@ class RemoteCollector:
             timestamp=datetime.now(tz=timezone.utc),
             status=status,
             gpus=gpus,
-            cpu=CpuInfo(percent=round(total_cpu, 1), core_count=1),
+            cpu=CpuInfo(percent=system_percent, core_count=core_count),
             memory=memory,
             ainrf_processes=ainrf_processes,
         )
+
+    async def _collect_core_count(self) -> int:
+        try:
+            result = await self._executor.run_command(
+                "nproc",
+                timeout=3,
+            )
+            if result.exit_code == 0:
+                return int(result.stdout.strip())
+        except Exception:
+            pass
+        return 1
 
     async def _collect_memory(self) -> MemoryInfo:
         try:

--- a/src/ainrf/monitor/models.py
+++ b/src/ainrf/monitor/models.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class GpuInfo(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    index: int
+    name: str
+    utilization_percent: float
+    memory_used_mb: int
+    memory_total_mb: int
+
+
+class CpuInfo(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    percent: float
+    core_count: int = 1
+
+
+class MemoryInfo(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    used_mb: int
+    total_mb: int
+    percent: float
+
+
+class ProcessInfo(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    pid: int
+    name: str
+    cpu_percent: float
+    memory_mb: int
+    runtime_seconds: int
+
+
+class ResourceSnapshot(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    environment_id: str
+    environment_name: str
+    timestamp: datetime
+    status: Literal["ok", "degraded", "unavailable"] = "ok"
+    gpus: list[GpuInfo] = Field(default_factory=list)
+    cpu: CpuInfo
+    memory: MemoryInfo
+    ainrf_processes: list[ProcessInfo] = Field(default_factory=list)
+
+
+class ResourcesResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    items: list[ResourceSnapshot] = Field(default_factory=list)

--- a/src/ainrf/monitor/process_tree.py
+++ b/src/ainrf/monitor/process_tree.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RawProcess:
+    pid: int
+    ppid: int
+    name: str
+    cpu_percent: float
+    memory_mb: int
+    runtime_seconds: int
+
+
+class ProcessTreeFilter:
+    WHITELIST = {"ainrf", "python", "uv", "node", "tmux", "code-server"}
+
+    def __init__(self, root_pid: int) -> None:
+        self.root_pid = root_pid
+
+    def collect_ainrf_processes(self, all_processes: list[RawProcess]) -> list[RawProcess]:
+        pid_to_ppid = {p.pid: p.ppid for p in all_processes}
+        descendant_pids = self._collect_descendants(pid_to_ppid, self.root_pid)
+
+        result: list[RawProcess] = []
+        for process in all_processes:
+            if process.pid in descendant_pids:
+                result.append(process)
+            elif process.name in self.WHITELIST:
+                result.append(process)
+
+        return sorted(result, key=lambda p: p.cpu_percent, reverse=True)
+
+    def _collect_descendants(self, pid_to_ppid: dict[int, int], root: int) -> set[int]:
+        descendants: set[int] = {root}
+        changed = True
+        while changed:
+            changed = False
+            for pid, ppid in pid_to_ppid.items():
+                if ppid in descendants and pid not in descendants:
+                    descendants.add(pid)
+                    changed = True
+        return descendants

--- a/src/ainrf/monitor/service.py
+++ b/src/ainrf/monitor/service.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from ainrf.monitor.collectors import LocalCollector, RemoteCollector
+from ainrf.monitor.models import ResourceSnapshot
+
+if TYPE_CHECKING:
+    from ainrf.environments.service import InMemoryEnvironmentService
+
+logger = logging.getLogger(__name__)
+
+
+class ResourceMonitorService:
+    def __init__(self, environment_service: InMemoryEnvironmentService) -> None:
+        self._environment_service = environment_service
+        self._snapshots: dict[str, ResourceSnapshot] = {}
+        self._task: asyncio.Task[None] | None = None
+        self._local_collector = LocalCollector()
+
+    async def start(self) -> None:
+        self._task = asyncio.create_task(self._loop())
+
+    async def stop(self) -> None:
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+    async def _loop(self) -> None:
+        while True:
+            try:
+                await self._collect_all()
+            except Exception:
+                logger.exception("Resource collection failed")
+            await asyncio.sleep(2)
+
+    async def _collect_all(self) -> None:
+        from ainrf.environments.probing import _ssh_container_for
+        from ainrf.execution.ssh import SSHExecutor
+
+        environments = self._environment_service.list_environments()
+
+        for env in environments:
+            try:
+                if env.id == "env-localhost":
+                    snapshot = await self._local_collector.collect()
+                else:
+                    container = _ssh_container_for(env)
+                    executor = SSHExecutor(container)
+                    collector = RemoteCollector(executor, env.id, env.display_name)
+                    snapshot = await collector.collect()
+
+                self._snapshots[env.id] = snapshot
+            except Exception as exc:
+                logger.warning("Failed to collect resources for %s: %s", env.id, exc)
+                if env.id in self._snapshots:
+                    old = self._snapshots[env.id]
+                    self._snapshots[env.id] = ResourceSnapshot(
+                        environment_id=env.id,
+                        environment_name=env.display_name,
+                        timestamp=datetime.now(tz=timezone.utc),
+                        status="degraded",
+                        gpus=old.gpus,
+                        cpu=old.cpu,
+                        memory=old.memory,
+                        ainrf_processes=old.ainrf_processes,
+                    )
+
+    def get_snapshots(self) -> dict[str, ResourceSnapshot]:
+        return self._snapshots.copy()

--- a/src/ainrf/monitor/service.py
+++ b/src/ainrf/monitor/service.py
@@ -54,8 +54,11 @@ class ResourceMonitorService:
                 else:
                     container = _ssh_container_for(env)
                     executor = SSHExecutor(container)
-                    collector = RemoteCollector(executor, env.id, env.display_name)
-                    snapshot = await collector.collect()
+                    try:
+                        collector = RemoteCollector(executor, env.id, env.display_name)
+                        snapshot = await collector.collect()
+                    finally:
+                        await executor.close()
 
                 self._snapshots[env.id] = snapshot
             except Exception as exc:

--- a/tests/test_api_resources.py
+++ b/tests/test_api_resources.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from ainrf.api.app import create_app
+from ainrf.api.config import ApiConfig, hash_api_key
+from ainrf.execution import ContainerConfig
+
+
+@pytest.mark.anyio
+async def test_get_resources_returns_list(tmp_path: Path) -> None:
+    app = create_app(
+        ApiConfig(
+            api_key_hashes=frozenset({hash_api_key("secret-key")}),
+            state_root=tmp_path,
+            container_config=ContainerConfig(host="gpu-server-01", user="root"),
+        )
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://testserver",
+        headers={"X-API-Key": "secret-key"},
+    ) as client:
+        response = await client.get("/resources")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "items" in data
+    assert isinstance(data["items"], list)

--- a/tests/test_monitor_collectors.py
+++ b/tests/test_monitor_collectors.py
@@ -24,13 +24,16 @@ class TestParseNvidiaSmi:
 
 class TestParsePsOutput:
     def test_parse_valid_output(self):
-        stdout = "PID PPID COMM %CPU %MEM ELAPSED\n1 0 systemd 0.1 0.5 01:23:45\n100 1 ainrf 5.0 2.0 00:10:30\n"
+        # 5th column is rss in KB (e.g. 10240 KB = 10 MB, 524288 KB = 512 MB)
+        stdout = "PID PPID COMM %CPU RSS ELAPSED\n1 0 systemd 0.1 10240 01:23:45\n100 1 ainrf 5.0 524288 00:10:30\n"
         result = parse_ps_output(stdout)
         assert len(result) == 2
         assert result[0].pid == 1
         assert result[0].name == "systemd"
+        assert result[0].memory_mb == 10
         assert result[1].pid == 100
         assert result[1].cpu_percent == 5.0
+        assert result[1].memory_mb == 512
 
     def test_parse_empty_output(self):
         result = parse_ps_output("")

--- a/tests/test_monitor_collectors.py
+++ b/tests/test_monitor_collectors.py
@@ -1,0 +1,37 @@
+from ainrf.monitor.collectors import parse_nvidia_smi_csv, parse_ps_output
+
+
+class TestParseNvidiaSmi:
+    def test_parse_valid_output(self):
+        stdout = "0, NVIDIA GeForce RTX 4090, 45 %, 8192 MiB, 24576 MiB\n"
+        result = parse_nvidia_smi_csv(stdout)
+        assert len(result) == 1
+        assert result[0].index == 0
+        assert result[0].name == "NVIDIA GeForce RTX 4090"
+        assert result[0].utilization_percent == 45.0
+        assert result[0].memory_used_mb == 8192
+        assert result[0].memory_total_mb == 24576
+
+    def test_parse_empty_output(self):
+        result = parse_nvidia_smi_csv("")
+        assert result == []
+
+    def test_parse_header_only(self):
+        stdout = "index, name, utilization.gpu [%], memory.used [MiB], memory.total [MiB]\n"
+        result = parse_nvidia_smi_csv(stdout)
+        assert result == []
+
+
+class TestParsePsOutput:
+    def test_parse_valid_output(self):
+        stdout = "PID PPID COMM %CPU %MEM ELAPSED\n1 0 systemd 0.1 0.5 01:23:45\n100 1 ainrf 5.0 2.0 00:10:30\n"
+        result = parse_ps_output(stdout)
+        assert len(result) == 2
+        assert result[0].pid == 1
+        assert result[0].name == "systemd"
+        assert result[1].pid == 100
+        assert result[1].cpu_percent == 5.0
+
+    def test_parse_empty_output(self):
+        result = parse_ps_output("")
+        assert result == []

--- a/tests/test_monitor_collectors.py
+++ b/tests/test_monitor_collectors.py
@@ -24,8 +24,12 @@ class TestParseNvidiaSmi:
 
 class TestParsePsOutput:
     def test_parse_valid_output(self):
-        # 5th column is rss in KB (e.g. 10240 KB = 10 MB, 524288 KB = 512 MB)
-        stdout = "PID PPID COMM %CPU RSS ELAPSED\n1 0 systemd 0.1 10240 01:23:45\n100 1 ainrf 5.0 524288 00:10:30\n"
+        # Format: pid,ppid,pcpu,rss,etime,comm  (comm last, may contain spaces)
+        stdout = (
+            "PID PPID %CPU RSS ELAPSED COMM\n"
+            "1 0 0.1 10240 01:23:45 systemd\n"
+            "100 1 5.0 524288 00:10:30 ainrf\n"
+        )
         result = parse_ps_output(stdout)
         assert len(result) == 2
         assert result[0].pid == 1
@@ -34,6 +38,20 @@ class TestParsePsOutput:
         assert result[1].pid == 100
         assert result[1].cpu_percent == 5.0
         assert result[1].memory_mb == 512
+
+    def test_parse_comm_with_spaces(self):
+        # comm is the last column and may contain spaces
+        stdout = (
+            "PID PPID %CPU RSS ELAPSED COMM\n"
+            "1 0 0.1 10240 01:23:45 systemd\n"
+            "200 1 2.5 20480 00:05:00 code server\n"
+        )
+        result = parse_ps_output(stdout)
+        assert len(result) == 2
+        assert result[1].pid == 200
+        assert result[1].name == "code server"
+        assert result[1].cpu_percent == 2.5
+        assert result[1].memory_mb == 20
 
     def test_parse_empty_output(self):
         result = parse_ps_output("")

--- a/tests/test_monitor_process_tree.py
+++ b/tests/test_monitor_process_tree.py
@@ -1,0 +1,34 @@
+from ainrf.monitor.process_tree import ProcessTreeFilter, RawProcess
+
+
+class TestProcessTreeFilter:
+    def test_collect_descendants(self):
+        processes = [
+            RawProcess(pid=1, ppid=0, name="systemd", cpu_percent=0.1, memory_mb=10, runtime_seconds=100),
+            RawProcess(pid=100, ppid=1, name="ainrf", cpu_percent=5.0, memory_mb=100, runtime_seconds=50),
+            RawProcess(pid=101, ppid=100, name="python", cpu_percent=3.0, memory_mb=80, runtime_seconds=40),
+            RawProcess(pid=102, ppid=100, name="node", cpu_percent=2.0, memory_mb=60, runtime_seconds=30),
+            RawProcess(pid=103, ppid=101, name="uv", cpu_percent=1.0, memory_mb=20, runtime_seconds=20),
+            RawProcess(pid=200, ppid=1, name="sshd", cpu_percent=0.5, memory_mb=15, runtime_seconds=60),
+        ]
+        filter_ = ProcessTreeFilter(root_pid=100)
+        result = filter_.collect_ainrf_processes(processes)
+        pids = {p.pid for p in result}
+        assert pids == {100, 101, 102, 103}
+
+    def test_whitelist_includes_non_descendants(self):
+        processes = [
+            RawProcess(pid=1, ppid=0, name="systemd", cpu_percent=0.1, memory_mb=10, runtime_seconds=100),
+            RawProcess(pid=100, ppid=1, name="ainrf", cpu_percent=5.0, memory_mb=100, runtime_seconds=50),
+            RawProcess(pid=500, ppid=1, name="tmux", cpu_percent=0.5, memory_mb=20, runtime_seconds=60),
+            RawProcess(pid=501, ppid=500, name="code-server", cpu_percent=1.0, memory_mb=50, runtime_seconds=30),
+        ]
+        filter_ = ProcessTreeFilter(root_pid=100)
+        result = filter_.collect_ainrf_processes(processes)
+        pids = {p.pid for p in result}
+        assert pids == {100, 500, 501}
+
+    def test_empty_processes(self):
+        filter_ = ProcessTreeFilter(root_pid=100)
+        result = filter_.collect_ainrf_processes([])
+        assert result == []

--- a/tests/test_monitor_service.py
+++ b/tests/test_monitor_service.py
@@ -1,0 +1,33 @@
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from ainrf.monitor.models import CpuInfo, MemoryInfo, ResourceSnapshot
+from ainrf.monitor.service import ResourceMonitorService
+
+
+class TestResourceMonitorService:
+    @pytest.fixture
+    def mock_env_service(self):
+        service = MagicMock()
+        service.list_environments.return_value = []
+        return service
+
+    def test_get_snapshots_empty(self, mock_env_service):
+        service = ResourceMonitorService(mock_env_service)
+        assert service.get_snapshots() == {}
+
+    def test_get_snapshots_returns_copy(self, mock_env_service):
+        service = ResourceMonitorService(mock_env_service)
+        snapshot = ResourceSnapshot(
+            environment_id="test",
+            environment_name="Test",
+            timestamp=datetime.now(tz=timezone.utc),
+            cpu=CpuInfo(percent=10.0, core_count=4),
+            memory=MemoryInfo(used_mb=1000, total_mb=8000, percent=12.5),
+        )
+        service._snapshots = {"test": snapshot}
+        result = service.get_snapshots()
+        assert "test" in result
+        assert result["test"].environment_id == "test"


### PR DESCRIPTION
## Summary

- Add backend resource monitoring system with local (subprocess) and remote (SSH) collectors
- Background asyncio task polls every 2s, caches snapshots in memory
- PID tree + whitelist filtering identifies AINRF and related child processes
- Add GET /resources API endpoint returning all environment snapshots
- Add frontend resource monitoring page at /resources with:
  - GPU utilization bars, CPU ring chart, memory bar (pure Tailwind CSS)
  - AINRF process table sorted by CPU%
  - 5-second React Query polling with stale-time caching
- Add navigation item and route integration
- Add frontend unit tests for ResourcesPage

## Test Plan

- [ ] Run uv run pytest — monitor tests (11) + API route test should pass
- [ ] Run cd frontend && node_modules/.bin/tsc -b — TypeScript clean
- [ ] Run cd frontend && npm run test:run -- src/pages/ResourcesPage.test.tsx — 5 tests pass
- [ ] Open /resources in browser and verify GPU/CPU/memory displays update