### PR TITLE
feat(perf): add full-stack performance audit toolchain

### DIFF
--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -1,0 +1,58 @@
+name: Performance Check
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Subsystem to audit'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - backend
+          - frontend
+          - db
+
+jobs:
+  perf-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Install Python dependencies
+        run: uv sync
+
+      - name: Install py-spy
+        run: pip install py-spy
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install frontend dependencies
+        run: cd frontend && npm ci
+
+      - name: Start server
+        run: |
+          uv run ainrf serve --host 127.0.0.1 --port 8000 --state-root /tmp/ainrf-ci &
+          sleep 3
+
+      - name: Run performance audit
+        run: uv run python scripts/perf/run-all.py --target ${{ inputs.target }} --ci
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-report
+          path: .cache/perf-report/

--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,4 @@ kimi-export-*.md
 session-*.md
 
 # paper scratch
-paper-test/
+paper-test/.cache/perf-report/

--- a/docs/LLM-Working/worklog/2026-05-19.md
+++ b/docs/LLM-Working/worklog/2026-05-19.md
@@ -17,3 +17,11 @@ Changes:
   - Added `connectionLineStyle` and `defaultEdgeOptions` props to `<ReactFlow>` for consistent styling
 
 Verification: TypeScript `tsc -b` passed cleanly. All 119 frontend tests pass (2 skipped, unchanged).
+
+## 23:07 changelog: Complete 3 remaining code-review fixes (#3, #4, #11)
+
+- **#3 Frontend 401 auto-refresh race condition**: Added `_refreshPromise` module-level mutex so concurrent 401 responses share a single token refresh attempt instead of racing. Previously, multiple parallel API calls getting 401 would each try to refresh independently, with the first failure clearing tokens for the others.
+- **#4 Refresh token localStorage XSS risk**: Enhanced existing documentation comment with CSP mitigation note (`Content-Security-Policy` header recommendation).
+- **#11 Test fixture global state**: Created `tests/conftest.py` with a module-scoped autouse pytest fixture that calls `reset_app_instance()` before and after each test module. The `_testutil._ensure_app()` cached singleton was never cleaned between modules, risking cross-module state leakage.
+
+Verification: TypeScript `tsc -b` passed. All 119 frontend tests pass. Backend pytest passes (exit code 0, skipping 2 pre-existing unrelated failures in `test_read_file_too_large` and `test_serve_rejects_malformed_config`).

--- a/docs/superpowers/plans/2026-05-20-perf-audit-toolchain.md
+++ b/docs/superpowers/plans/2026-05-20-perf-audit-toolchain.md
@@ -1,0 +1,1422 @@
+# Performance Audit Toolchain Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a sustainable full-stack performance audit toolchain covering backend API benchmarks, py-spy hotspot sampling, SQLite index analysis, frontend bundle analysis, Lighthouse audits, and React Profiler reporting.
+
+**Architecture:** A `scripts/perf/` directory with independent sub-tools per subsystem, orchestrated by `run-all.py`. Each tool outputs to `.cache/perf-report/YYYY-MM-DD/`. The orchestrator supports `--target` filtering, `--ci` JSON mode, `--diff` historical comparison, and `--threshold` regression gating.
+
+**Tech Stack:** Python (pytest-benchmark, py-spy), Node (rollup-plugin-visualizer, lhci), React.Profiler API
+
+---
+
+## File Map
+
+| File | Responsibility |
+|------|---------------|
+| `scripts/perf/__init__.py` | Package marker |
+| `scripts/perf/_common.py` | Shared: date-based report dir, JSON merge, delta table formatter, threshold checker |
+| `scripts/perf/run-all.py` | Orchestrator: CLI with `--target`, `--ci`, `--diff`, `--threshold` |
+| `scripts/perf/backend/__init__.py` | Package marker |
+| `scripts/perf/backend/analyze_db.py` | SQLite schema scan, EXPLAIN QUERY PLAN, missing-index report |
+| `scripts/perf/backend/benchmark_api.py` | pytest-benchmark suite for API endpoint latency |
+| `scripts/perf/backend/profile_hot.py` | py-spy attach helper + workload trigger script |
+| `scripts/perf/frontend/bundle_report.mjs` | Vite build + visualizer + chunk-size scanner |
+| `scripts/perf/frontend/lighthouse.js` | LHCI collect/assert config |
+| `scripts/perf/react/profiler_report.py` | Parse React.Profiler JSON export into ranked table |
+| `frontend/vite.config.ts` | Add visualizer plugin (conditional) |
+| `frontend/src/App.tsx` | Add conditional `<React.Profiler>` wrapper |
+| `.github/workflows/perf-check.yml` | Manual CI workflow trigger |
+| `pyproject.toml` | Add `pytest-benchmark` dependency |
+| `frontend/package.json` | Add `rollup-plugin-visualizer`, `@lhci/cli` devDeps |
+
+---
+
+### Task 1: Shared Infrastructure
+
+**Files:**
+- Create: `scripts/perf/__init__.py`
+- Create: `scripts/perf/_common.py`
+- Create: `scripts/perf/backend/__init__.py`
+
+- [ ] **Step 1: Create `scripts/perf/__init__.py`**
+
+```python
+"""Performance audit toolchain."""
+```
+
+- [ ] **Step 2: Create `scripts/perf/backend/__init__.py`**
+
+```python
+"""Backend performance measurement tools."""
+```
+
+- [ ] **Step 3: Write `scripts/perf/_common.py`**
+
+```python
+"""Shared utilities for the performance audit toolchain."""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+REPORT_BASE = REPO_ROOT / ".cache" / "perf-report"
+
+
+def today_dir() -> Path:
+    """Return and create the dated report directory for today."""
+    date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    d = REPORT_BASE / date_str
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def read_summary(report_dir: Path) -> dict:
+    """Read summary.json from a report directory, returning {} if missing."""
+    path = report_dir / "summary.json"
+    if path.exists():
+        return json.loads(path.read_text())
+    return {}
+
+
+def write_summary(report_dir: Path, data: dict) -> None:
+    """Write summary.json to a report directory."""
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "summary.json").write_text(json.dumps(data, indent=2))
+
+
+def merge_json_files(dir_path: Path, glob_pattern: str) -> dict:
+    """Merge all JSON files matching glob_pattern into a single dict keyed by filename stem."""
+    merged: dict = {}
+    for f in sorted(dir_path.glob(glob_pattern)):
+        try:
+            merged[f.stem] = json.loads(f.read_text())
+        except (json.JSONDecodeError, OSError):
+            merged[f.stem] = {"error": f"Failed to parse {f.name}"}
+    return merged
+
+
+def delta_table(prev: dict, curr: dict, metrics: list[tuple[str, str]]) -> str:
+    """Build a terminal delta table comparing two summary dicts.
+
+    Args:
+        prev: Previous summary dict.
+        curr: Current summary dict.
+        metrics: List of (label, dotted_key_path) pairs, e.g. [("API login p50", "api.login.p50")].
+
+    Returns:
+        Formatted table string.
+    """
+    lines = [
+        f"{'Metric':<40} {'Previous':>12} {'Current':>12} {'Delta':>10}",
+        "-" * 74,
+    ]
+
+    def _get(d: dict, path: str):
+        keys = path.split(".")
+        v = d
+        for k in keys:
+            v = v.get(k, {}) if isinstance(v, dict) else {}
+        return v if isinstance(v, (int, float)) else None
+
+    for label, key_path in metrics:
+        pv = _get(prev, key_path)
+        cv = _get(curr, key_path)
+        if pv is not None and cv is not None and pv != 0:
+            delta = (cv - pv) / pv * 100
+            pv_str = f"{pv:.1f}"
+            cv_str = f"{cv:.1f}"
+            delta_str = f"{delta:+.1f}%"
+        else:
+            pv_str = str(pv) if pv is not None else "N/A"
+            cv_str = str(cv) if cv is not None else "N/A"
+            delta_str = "N/A"
+        lines.append(f"{label:<40} {pv_str:>12} {cv_str:>12} {delta_str:>10}")
+
+    return "\n".join(lines)
+
+
+def check_thresholds(summary: dict, thresholds: dict[str, float]) -> list[str]:
+    """Check summary values against thresholds. Returns list of violation messages."""
+    violations: list[str] = []
+    for path, limit in thresholds.items():
+        keys = path.split(".")
+        v = summary
+        for k in keys:
+            v = v.get(k, {}) if isinstance(v, dict) else 0
+        if isinstance(v, (int, float)) and v > limit:
+            violations.append(f"{path}: {v:.1f} > {limit:.1f}")
+    return violations
+
+
+def fail(msg: str) -> None:
+    """Print error and exit non-zero."""
+    print(f"ERROR: {msg}", file=sys.stderr)
+    sys.exit(1)
+```
+
+- [ ] **Step 4: Verify module imports**
+
+```bash
+uv run python -c "from scripts.perf._common import today_dir, write_summary, delta_table; print('OK')"
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/perf/__init__.py scripts/perf/_common.py scripts/perf/backend/__init__.py
+git commit -m "feat(perf): add shared infrastructure for performance audit toolchain"
+```
+
+---
+
+### Task 2: Database Index Analyzer
+
+**Files:**
+- Create: `scripts/perf/backend/analyze_db.py`
+
+- [ ] **Step 1: Write `scripts/perf/backend/analyze_db.py`**
+
+```python
+"""SQLite index analyzer — scans all project databases for missing indexes."""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+STATE_ROOT = Path.home() / ".ainrf" / "runtime"
+
+# Column names frequently used in WHERE / JOIN / ORDER BY clauses that should be indexed
+WATCH_COLUMNS = {
+    "task_harness_tasks": ["project_id", "status", "environment_id", "workspace_id", "session_id", "owner_user_id", "created_at"],
+    "task_harness_output_events": ["kind"],
+    "task_harness_edges": ["project_id", "source_task_id", "target_task_id"],
+    "managed_tasks": ["environment_id", "status", "task_id"],
+    "task_terminal_bindings": ["status", "ownership_user_id", "agent_write_state"],
+    "task_sessions": ["project_id", "status", "created_at"],
+    "task_attempts": ["session_id", "parent_attempt_id", "status"],
+    "users": ["username", "status"],
+    "refresh_tokens": ["user_id", "expires_at"],
+}
+
+# Queries to EXPLAIN — these represent common API call paths
+EXPLAIN_QUERIES: dict[str, list[tuple[str, str]]] = {
+    "task_harness.sqlite3": [
+        ("list_tasks_by_project",
+         "SELECT task_id FROM task_harness_tasks WHERE project_id = ? AND status != 'archived'"),
+        ("list_output_by_task",
+         "SELECT seq, kind, data FROM task_harness_output_events WHERE task_id = ? AND seq > ?"),
+        ("list_edges_by_project",
+         "SELECT edge_id, source_task_id, target_task_id FROM task_harness_edges WHERE project_id = ?"),
+    ],
+    "auth.sqlite3": [
+        ("login_lookup", "SELECT id, password_hash, role, status FROM users WHERE username = ?"),
+        ("list_collaborators",
+         "SELECT user_id, role FROM project_collaborators WHERE project_id = ?"),
+    ],
+    "sessions.sqlite3": [
+        ("list_sessions",
+         "SELECT session_id, title, status FROM task_sessions WHERE project_id = ? ORDER BY created_at DESC"),
+        ("list_attempts",
+         "SELECT attempt_id, status, started_at FROM task_attempts WHERE session_id = ? ORDER BY started_at DESC"),
+    ],
+}
+
+
+def get_tables(conn: sqlite3.Connection) -> list[str]:
+    return [r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")]
+
+
+def get_indexed_columns(conn: sqlite3.Connection) -> dict[str, set[str]]:
+    """Return {table_name: {indexed_column_names}} including PK columns."""
+    indexed: dict[str, set[str]] = {}
+    for (tbl,) in conn.execute("SELECT name FROM sqlite_master WHERE type='table'"):
+        cols: set[str] = set()
+        # Primary key columns
+        pk_rows = conn.execute(f"PRAGMA table_info('{tbl}')")
+        for row in pk_rows:
+            if row[5]:  # pk flag
+                cols.add(row[1])
+        # Index columns
+        idx_rows = conn.execute(f"PRAGMA index_list('{tbl}')")
+        for idx_row in idx_rows:
+            info_rows = conn.execute(f"PRAGMA index_info('{idx_row[1]}')")
+            for info_row in info_rows:
+                cols.add(info_row[2])
+        indexed[tbl] = cols
+    return indexed
+
+
+def analyze_db(db_path: Path) -> dict:
+    """Analyze a single SQLite database. Returns findings dict."""
+    findings: dict[str, list[str]] = {"missing_indexes": [], "full_scans": [], "tables": []}
+    if not db_path.exists():
+        findings["error"] = f"Database not found: {db_path}"
+        return findings
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        tables = get_tables(conn)
+        findings["tables"] = tables
+        indexed = get_indexed_columns(conn)
+
+        # Check missing indexes
+        for tbl in tables:
+            if tbl in WATCH_COLUMNS:
+                need = WATCH_COLUMNS[tbl]
+                have = indexed.get(tbl, set())
+                for col in need:
+                    if col not in have:
+                        findings["missing_indexes"].append(f"{db_path.name}:{tbl}.{col}")
+
+        # EXPLAIN QUERY PLAN for core queries
+        db_key = db_path.name
+        if db_key in EXPLAIN_QUERIES:
+            for label, query in EXPLAIN_QUERIES[db_key]:
+                try:
+                    plan_rows = conn.execute(f"EXPLAIN QUERY PLAN {query}", ("?",) * query.count("?")).fetchall()
+                    plan_text = "\n".join(
+                        f"  {r[0]}|{r[1]}|{r[2]}|{r[3]}"
+                        for r in plan_rows
+                    )
+                    if "SCAN TABLE" in plan_text:
+                        findings["full_scans"].append(f"{db_key}:{label}\n{plan_text}")
+                except Exception:
+                    findings["full_scans"].append(f"{db_key}:{label} (EXPLAIN failed)")
+
+    finally:
+        conn.close()
+
+    return findings
+
+
+def render_report(all_findings: dict[str, dict]) -> str:
+    """Render findings as a Markdown report."""
+    lines = ["# Database Index Analysis Report", "", f"**State root:** `{STATE_ROOT}`", ""]
+    for db_key, findings in sorted(all_findings.items()):
+        lines.append(f"## {db_key}")
+        lines.append("")
+        if "error" in findings:
+            lines.append(f"**Error:** {findings['error']}")
+            lines.append("")
+            continue
+
+        lines.append(f"Tables: {', '.join(findings.get('tables', []))}")
+        lines.append("")
+
+        missing = findings.get("missing_indexes", [])
+        if missing:
+            lines.append("### Missing Indexes")
+            for m in sorted(missing):
+                lines.append(f"- `CREATE INDEX ON {m.split(':')[1]}` — `{m}`")
+            lines.append("")
+
+        scans = findings.get("full_scans", [])
+        if scans:
+            lines.append("### Full Table Scans")
+            for s in scans:
+                lines.append(f"```\n{s}\n```")
+            lines.append("")
+        else:
+            lines.append("*No full table scans detected in core queries.*")
+            lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    from scripts.perf._common import today_dir
+
+    report_dir = today_dir()
+    all_findings: dict[str, dict] = {}
+
+    for db_name in ["auth.sqlite3", "sessions.sqlite3", "task_harness.sqlite3", "terminal_state.sqlite3"]:
+        db_path = STATE_ROOT / db_name
+        all_findings[db_name] = analyze_db(db_path)
+
+    report_md = render_report(all_findings)
+    out_path = report_dir / "db-index-report.md"
+    out_path.write_text(report_md)
+    print(f"Database index report written to {out_path}")
+
+    # Also write JSON summary for the master summary
+    import json
+    (report_dir / "db-summary.json").write_text(json.dumps({
+        db: {
+            "missing_index_count": len(f.get("missing_indexes", [])),
+            "full_scan_count": len(f.get("full_scans", [])),
+        }
+        for db, f in all_findings.items()
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Run the analyzer**
+
+```bash
+uv run python scripts/perf/backend/analyze_db.py
+```
+
+Expected: creates `.cache/perf-report/YYYY-MM-DD/db-index-report.md` and `db-summary.json`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/perf/backend/analyze_db.py
+git commit -m "feat(perf): add SQLite index analyzer with EXPLAIN QUERY PLAN checker"
+```
+
+---
+
+### Task 3: API Benchmark Suite
+
+**Files:**
+- Create: `scripts/perf/backend/benchmark_api.py`
+- Modify: `pyproject.toml` (add dependency)
+
+- [ ] **Step 1: Add `pytest-benchmark` to `pyproject.toml`**
+
+Add `"pytest-benchmark>=5.1"` to the `dependencies` list in `pyproject.toml`.
+
+- [ ] **Step 2: Install the new dependency**
+
+```bash
+uv sync
+```
+
+- [ ] **Step 3: Write `scripts/perf/backend/benchmark_api.py`**
+
+```python
+"""API latency benchmarks using pytest-benchmark.
+
+Usage: uv run pytest scripts/perf/backend/benchmark_api.py --benchmark-only --benchmark-json=.cache/perf-report/YYYY-MM-DD/api-benchmark.json
+
+Requires a running AINRF server at http://127.0.0.1:8000 with a test admin user.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import httpx
+import pytest
+
+BASE_URL = os.environ.get("AINRF_PERF_BASE_URL", "http://127.0.0.1:8000")
+ADMIN_USER = os.environ.get("AINRF_PERF_USER", "perf-admin")
+ADMIN_PASS = os.environ.get("AINRF_PERF_PASS", "perf-test-pass")
+
+
+def _admin_headers(client: httpx.Client) -> dict:
+    """Get admin JWT headers, registering the perf user if needed."""
+    # Try login
+    resp = client.post(f"{BASE_URL}/auth/login", json={"username": ADMIN_USER, "password": ADMIN_PASS})
+    if resp.status_code == 200:
+        token = resp.json()["access_token"]
+    else:
+        # Register then activate
+        client.post(f"{BASE_URL}/auth/register", json={
+            "username": ADMIN_USER, "display_name": "Perf Admin", "password": ADMIN_PASS,
+        })
+        # Login — will fail if must_change_password or pending
+        resp2 = client.post(f"{BASE_URL}/auth/login", json={"username": ADMIN_USER, "password": ADMIN_PASS})
+        if resp2.status_code != 200:
+            pytest.skip(f"Cannot authenticate perf user: {resp2.text}")
+        token = resp2.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture(scope="module")
+def client():
+    with httpx.Client(base_url=BASE_URL, timeout=30) as c:
+        yield c
+
+
+@pytest.fixture(scope="module")
+def auth_headers(client):
+    return _admin_headers(client)
+
+
+# ---- Auth endpoints ----
+
+def test_login(benchmark, client):
+    benchmark(lambda: client.post(f"{BASE_URL}/auth/login", json={"username": ADMIN_USER, "password": ADMIN_PASS}))
+
+
+def test_auth_me(benchmark, client, auth_headers):
+    benchmark(lambda: client.get(f"{BASE_URL}/auth/me", headers=auth_headers))
+
+
+# ---- Project endpoints ----
+
+def test_list_projects(benchmark, client, auth_headers):
+    benchmark(lambda: client.get(f"{BASE_URL}/projects", headers=auth_headers))
+
+
+def test_list_tasks(benchmark, client, auth_headers):
+    benchmark(lambda: client.get(f"{BASE_URL}/projects/default/tasks", headers=auth_headers))
+
+
+def test_list_task_edges(benchmark, client, auth_headers):
+    benchmark(lambda: client.get(f"{BASE_URL}/projects/default/task-edges", headers=auth_headers))
+
+
+# ---- File endpoints ----
+
+def test_file_list(benchmark, client, auth_headers):
+    benchmark(lambda: client.get(f"{BASE_URL}/files/list?environment_id=env-localhost&path=/", headers=auth_headers))
+
+
+# ---- Session endpoints ----
+
+def test_list_sessions(benchmark, client, auth_headers):
+    benchmark(lambda: client.get(f"{BASE_URL}/sessions", headers=auth_headers))
+
+
+# ---- Task creation (lightweight — no execution engine during bench) ----
+# NOTE: This creates a real task record. Use a dedicated test project in CI.
+
+def test_create_task_minimal(benchmark, client, auth_headers):
+    payload = {
+        "project_id": "default",
+        "workspace_id": "workspace-default",
+        "environment_id": "env-localhost",
+        "task_profile": "claude-code",
+        "task_input": "benchmark",
+        "title": "perf-bench-task",
+    }
+    benchmark(lambda: client.post(f"{BASE_URL}/tasks", json=payload, headers=auth_headers))
+```
+
+- [ ] **Step 4: Run the benchmarks**
+
+First ensure the server is running, then:
+
+```bash
+uv run pytest scripts/perf/backend/benchmark_api.py --benchmark-only --benchmark-json=.cache/perf-report/$(date +%Y-%m-%d)/api-benchmark.json --benchmark-min-rounds=10 --benchmark-max-time=0.5
+```
+
+Expected: JSON output at the specified path with p50/p95/p99 stats per test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/perf/backend/benchmark_api.py pyproject.toml uv.lock
+git commit -m "feat(perf): add API latency benchmark suite with pytest-benchmark"
+```
+
+---
+
+### Task 4: Hotspot Profiler (py-spy)
+
+**Files:**
+- Create: `scripts/perf/backend/profile_hot.py`
+
+- [ ] **Step 1: Write `scripts/perf/backend/profile_hot.py`**
+
+```python
+"""py-spy hotspot profiler helper.
+
+Attaches py-spy to the running AINRF server process and triggers a
+representative workload, producing a flamegraph SVG.
+
+Requires: py-spy (pip install py-spy)
+Requires: A running AINRF server with a known PID.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+BASE_URL = os.environ.get("AINRF_PERF_BASE_URL", "http://127.0.0.1:8000")
+STATE_ROOT = Path(os.environ.get("AINRF_STATE_ROOT", Path.home() / ".ainrf"))
+PID_FILE = STATE_ROOT / "server.pid"
+DURATION = int(os.environ.get("AINRF_PERF_PROFILE_DURATION", "30"))
+
+WORKLOAD_SCRIPT = '''
+import httpx, os, sys, json
+BASE = os.environ.get("AINRF_PERF_BASE_URL", "http://127.0.0.1:8000")
+
+def get_token():
+    r = httpx.post(f"{BASE}/auth/login", json={"username": "perf-admin", "password": "perf-test-pass"})
+    if r.status_code != 200:
+        r = httpx.post(f"{BASE}/auth/register", json={"username": "perf-admin", "display_name": "Perf Admin", "password": "perf-test-pass"})
+        r = httpx.post(f"{BASE}/auth/login", json={"username": "perf-admin", "password": "perf-test-pass"})
+    return r.json()["access_token"]
+
+token = get_token()
+h = {"Authorization": f"Bearer {token}"}
+
+for i in range(10):
+    httpx.get(f"{BASE}/projects/default/tasks", headers=h)
+    httpx.get(f"{BASE}/files/list?environment_id=env-localhost&path=/", headers=h)
+    httpx.post(f"{BASE}/tasks", json={
+        "project_id": "default", "workspace_id": "workspace-default",
+        "environment_id": "env-localhost", "task_profile": "claude-code",
+        "task_input": "perf profile", "title": f"perf-profile-{i}",
+    }, headers=h)
+'''
+
+WORKLOAD_SCRIPT_LINES = WORKLOAD_SCRIPT.strip().split('\n')
+
+
+def find_pid() -> int:
+    """Find the AINRF server PID from PID file or process search."""
+    if PID_FILE.exists():
+        return int(PID_FILE.read_text().strip())
+
+    # Fallback: find the uvicorn process
+    result = subprocess.run(
+        ["pgrep", "-f", "ainrf serve"],
+        capture_output=True, text=True,
+    )
+    if result.returncode == 0:
+        return int(result.stdout.strip().split('\n')[0])
+
+    print("ERROR: Cannot find AINRF server process. Start the server first or set AINRF_STATE_ROOT.", file=sys.stderr)
+    sys.exit(1)
+
+
+def main() -> None:
+    from scripts.perf._common import today_dir
+
+    report_dir = today_dir()
+
+    # Check py-spy is available
+    try:
+        subprocess.run(["py-spy", "--version"], capture_output=True, check=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        print("ERROR: py-spy not found. Install with: pip install py-spy")
+        sys.exit(1)
+
+    pid = find_pid()
+    flamegraph_path = report_dir / "flamegraph.svg"
+
+    print(f"Profiling PID {pid} for {DURATION}s...")
+
+    # Start py-spy in background
+    py_spy = subprocess.Popen([
+        "py-spy", "record",
+        "-o", str(flamegraph_path),
+        "--pid", str(pid),
+        "--duration", str(DURATION),
+        "--native",  # include native C extensions
+    ])
+
+    # Give py-spy a moment to attach, then trigger workload
+    time.sleep(1)
+    print("Triggering workload...")
+    subprocess.run(
+        [sys.executable, "-c", WORKLOAD_SCRIPT],
+        timeout=DURATION + 10,
+    )
+
+    # Wait for py-spy to finish
+    py_spy.wait(timeout=DURATION + 15)
+    print(f"Flamegraph written to {flamegraph_path}")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Install py-spy**
+
+```bash
+uv pip install py-spy
+```
+
+- [ ] **Step 3: Test that py-spy works**
+
+```bash
+py-spy --version
+```
+
+Expected: version output, no error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/perf/backend/profile_hot.py
+git commit -m "feat(perf): add py-spy hotspot profiler with workload trigger"
+```
+
+---
+
+### Task 5: Frontend Bundle Analyzer
+
+**Files:**
+- Modify: `frontend/vite.config.ts`
+- Modify: `frontend/package.json`
+- Create: `scripts/perf/frontend/bundle_report.mjs`
+
+- [ ] **Step 1: Add `rollup-plugin-visualizer` to `frontend/package.json` devDependencies**
+
+```bash
+cd frontend && npm install --save-dev rollup-plugin-visualizer
+```
+
+- [ ] **Step 2: Modify `frontend/vite.config.ts` to optionally enable visualizer**
+
+Add after the existing imports:
+
+```typescript
+import { visualizer } from 'rollup-plugin-visualizer'
+
+const ANALYZE = process.env.VITE_BUNDLE_ANALYZE === 'true'
+```
+
+In the `plugins` array, add after `react()` and `tailwindcss()`:
+
+```typescript
+...(ANALYZE ? [visualizer({
+  open: false,
+  gzipSize: true,
+  brotliSize: true,
+  filename: '.cache/perf-report/bundle-treemap.html',
+  template: 'treemap',
+})] : []),
+```
+
+- [ ] **Step 3: Write `scripts/perf/frontend/bundle_report.mjs`**
+
+```javascript
+#!/usr/bin/env node
+/**
+ * Bundle report script — builds the frontend with the visualizer plugin
+ * and scans output chunks for size anomalies.
+ */
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FRONTEND_DIR = join(__dirname, '..', '..', '..', 'frontend');
+const REPORT_DIR = join(__dirname, '..', '..', '..', '.cache', 'perf-report', new Date().toISOString().slice(0, 10));
+
+const CHUNK_WARN_KB = 500;
+
+function run(cmd, cwd = FRONTEND_DIR) {
+  console.log(`> ${cmd}`);
+  return execSync(cmd, { cwd, encoding: 'utf-8', stdio: 'inherit' });
+}
+
+// Step 1: Build with visualizer enabled
+console.log('Building frontend with bundle analyzer...');
+run('VITE_BUNDLE_ANALYZE=true npx vite build');
+
+// Move the treemap to the report dir
+const treemapSrc = join(FRONTEND_DIR, '.cache', 'perf-report', 'bundle-treemap.html');
+const treemapDst = join(REPORT_DIR, 'bundle-treemap.html');
+mkdirSync(REPORT_DIR, { recursive: true });
+try {
+  const treemapHtml = readFileSync(treemapSrc, 'utf-8');
+  writeFileSync(treemapDst, treemapHtml);
+  console.log(`Treemap written to ${treemapDst}`);
+} catch {
+  console.warn('Warning: treemap HTML not found.');
+}
+
+// Step 2: Collect chunk stats
+const distDir = join(FRONTEND_DIR, 'dist');
+const { readdirSync, statSync } = await import('node:fs');
+const { gzipSync, brotliCompressSync } = await import('node:zlib');
+
+function collectStats(dir) {
+  const chunks = [];
+  for (const entry of readdirSync(dir, { recursive: true, withFileTypes: true })) {
+    const fp = join(entry.parentPath || entry.path, entry.name);
+    if (entry.isFile() && (entry.name.endsWith('.js') || entry.name.endsWith('.css'))) {
+      const raw = readFileSync(fp);
+      chunks.push({
+        file: fp.replace(distDir + '/', ''),
+        rawBytes: raw.length,
+        gzipBytes: gzipSync(raw).length,
+        brotliBytes: brotliCompressSync(raw).length,
+      });
+    }
+  }
+  return chunks;
+}
+
+const chunks = collectStats(distDir);
+chunks.sort((a, b) => b.rawBytes - a.rawBytes);
+
+const statsPath = join(REPORT_DIR, 'bundle-stats.json');
+writeFileSync(statsPath, JSON.stringify({ chunks, warnings: [] }, null, 2));
+
+// Step 3: Scan for anomalies
+const warnings = [];
+for (const c of chunks) {
+  if (c.gzipBytes > CHUNK_WARN_KB * 1024) {
+    warnings.push(`LARGE CHUNK: ${c.file} — ${(c.gzipBytes / 1024).toFixed(1)}KB gzip`);
+  }
+}
+
+// Check for duplicate module patterns (simple heuristic)
+const filenames = chunks.map(c => c.file);
+for (const f of filenames) {
+  const base = f.split('/').pop();
+  const dupes = filenames.filter(x => x.endsWith(base) && x !== f);
+  for (const d of dupes) {
+    warnings.push(`DUPLICATE MODULE: ${f} and ${d} may be the same module in different chunks`);
+  }
+}
+
+if (warnings.length > 0) {
+  console.log('\n=== Bundle Warnings ===');
+  for (const w of warnings) console.log(`  ⚠  ${w}`);
+  writeFileSync(statsPath, JSON.stringify({ chunks, warnings }, null, 2));
+} else {
+  console.log('\nNo bundle size warnings.');
+}
+
+console.log(`\nBundle stats written to ${statsPath}`);
+```
+
+- [ ] **Step 4: Test the bundle report**
+
+```bash
+cd frontend && node ../scripts/perf/frontend/bundle_report.mjs
+```
+
+Expected: builds frontend, produces `.cache/perf-report/YYYY-MM-DD/bundle-treemap.html` and `bundle-stats.json`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd frontend && git add package.json package-lock.json ../scripts/perf/frontend/bundle_report.mjs vite.config.ts && git commit -m "feat(perf): add frontend bundle analyzer with size anomaly scanner"
+```
+
+---
+
+### Task 6: Lighthouse Audit
+
+**Files:**
+- Create: `scripts/perf/frontend/lighthouse.js`
+
+- [ ] **Step 1: Add `@lhci/cli` to devDependencies**
+
+```bash
+cd frontend && npm install --save-dev @lhci/cli
+```
+
+- [ ] **Step 2: Write `scripts/perf/frontend/lighthouse.js`**
+
+```javascript
+#!/usr/bin/env node
+/**
+ * Lighthouse CI audit for key pages.
+ *
+ * Usage: node scripts/perf/frontend/lighthouse.js [--url=http://localhost:5173]
+ *
+ * Requires a running frontend dev server.
+ */
+import { execSync } from 'node:child_process';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPORT_DIR = join(__dirname, '..', '..', '..', '.cache', 'perf-report', new Date().toISOString().slice(0, 10));
+
+const BASE_URL = process.argv.find(a => a.startsWith('--url='))?.split('=')[1] || 'http://localhost:5173';
+const PAGES = ['/login', '/projects', '/tasks'];
+
+function run(cmd) {
+  console.log(`> ${cmd}`);
+  execSync(cmd, { encoding: 'utf-8', stdio: 'inherit' });
+}
+
+mkdirSync(REPORT_DIR, { recursive: true });
+
+// Collect each page
+for (const page of PAGES) {
+  const url = `${BASE_URL}${page}`;
+  console.log(`\n=== Auditing ${url} ===`);
+  const slug = page.replace(/^\//, '').replace(/\//g, '-') || 'home';
+  const reportFile = join(REPORT_DIR, `lighthouse-${slug}.json`);
+  const htmlFile = join(REPORT_DIR, `lighthouse-${slug}.html`);
+
+  try {
+    run(`npx lhci collect --url="${url}" --numberOfRuns=3`);
+    run(`npx lhci upload --target=filesystem --outputDir="${REPORT_DIR}" --reportFilenamePattern="lighthouse-${slug}-%%datetime%%.%%ext%%"`);
+  } catch (e) {
+    console.warn(`Warning: Lighthouse audit failed for ${url}: ${e.message}`);
+  }
+}
+
+// Summary
+console.log(`\nLighthouse reports saved to ${REPORT_DIR}`);
+```
+
+- [ ] **Step 3: Test with the dev server running**
+
+```bash
+cd frontend && node ../scripts/perf/frontend/lighthouse.js
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd frontend && git add package.json package-lock.json ../scripts/perf/frontend/lighthouse.js && git commit -m "feat(perf): add Lighthouse CI audit for key frontend pages"
+```
+
+---
+
+### Task 7: React Profiler Integration
+
+**Files:**
+- Modify: `frontend/src/App.tsx`
+- Create: `scripts/perf/react/profiler_report.py`
+
+- [ ] **Step 1: Modify `frontend/src/App.tsx` to add conditional Profiler**
+
+Add import at top (after existing imports):
+
+```typescript
+import { Profiler, type ProfilerOnRenderCallback } from 'react';
+```
+
+After the existing `queryClient` declaration and before `AppRoutes`, add:
+
+```typescript
+const PROFILER_ENABLED = import.meta.env.VITE_PROFILE === 'true';
+
+const profilerData: Array<{
+  id: string;
+  phase: string;
+  actualDuration: number;
+  baseDuration: number;
+  commitTime: number;
+}> = [];
+
+const onRender: ProfilerOnRenderCallback = (
+  id, phase, actualDuration, baseDuration, startTime, commitTime,
+) => {
+  if (PROFILER_ENABLED) {
+    profilerData.push({ id, phase, actualDuration, baseDuration, commitTime });
+    if (profilerData.length >= 100) {
+      profilerData.splice(0, profilerData.length - 50);
+    }
+  }
+};
+
+// Expose profiler data to window for the report script to collect
+if (PROFILER_ENABLED && typeof window !== 'undefined') {
+  (window as unknown as Record<string, unknown>).__perfProfilerData = profilerData;
+}
+```
+
+Wrap the main content in `<Profiler>` — in the `AppRoutes` component, wrap the final JSX return in `<Profiler id="AppRoot" onRender={onRender}>...</Profiler>`.
+
+- [ ] **Step 2: Write `scripts/perf/react/profiler_report.py`**
+
+```python
+"""React Profiler data collection and reporting.
+
+Starts a tiny HTTP server that the frontend can POST profiler data to,
+then generates a ranked component render-time report.
+
+Usage:
+  # Terminal 1: Start the collection server
+  python scripts/perf/react/profiler_report.py --collect
+
+  # Terminal 2: Browse the app with VITE_PROFILE=true, then POST
+  curl -X POST http://localhost:9876/dump -d @- < /dev/null
+
+  # Or: Generate report from saved data
+  python scripts/perf/react/profiler_report.py --report .cache/perf-report/YYYY-MM-DD/react-render.json
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+COLLECTED: list[dict] = []
+
+
+class CollectHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        path = urlparse(self.path).path
+        if path == "/collect":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length)
+            data = json.loads(body)
+            COLLECTED.extend(data if isinstance(data, list) else [data])
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(json.dumps({"received": len(COLLECTED)}).encode())
+        elif path == "/dump":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(json.dumps(COLLECTED).encode())
+        elif path == "/reset":
+            COLLECTED.clear()
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"{}")
+
+    def do_GET(self):
+        if urlparse(self.path).path == "/dump":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(json.dumps(COLLECTED).encode())
+
+
+def start_collect_server(port: int = 9876) -> None:
+    print(f"Profiler collection server listening on :{port}")
+    server = HTTPServer(("127.0.0.1", port), CollectHandler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    server.server_close()
+
+
+def generate_report(data: list[dict]) -> dict:
+    """Aggregate profiler data by component id."""
+    by_id: dict[str, dict] = {}
+    for entry in data:
+        cid = entry["id"]
+        if cid not in by_id:
+            by_id[cid] = {"id": cid, "calls": 0, "total_ms": 0.0, "max_ms": 0.0}
+        by_id[cid]["calls"] += 1
+        by_id[cid]["total_ms"] += entry["actualDuration"]
+        by_id[cid]["max_ms"] = max(by_id[cid]["max_ms"], entry["actualDuration"])
+
+    ranked = sorted(by_id.values(), key=lambda x: x["total_ms"], reverse=True)
+    return {
+        "components": ranked,
+        "total_entries": len(data),
+        "total_duration_ms": sum(d["actualDuration"] for d in data),
+    }
+
+
+def main() -> None:
+    from scripts.perf._common import today_dir
+
+    if "--collect" in sys.argv:
+        start_collect_server()
+        return
+
+    if "--report" in sys.argv:
+        idx = sys.argv.index("--report")
+        path = Path(sys.argv[idx + 1]) if idx + 1 < len(sys.argv) else None
+    else:
+        path = today_dir() / "react-render.json"
+
+    if path and path.exists():
+        data = json.loads(path.read_text())
+        report = generate_report(data)
+    elif path:
+        print(f"No data file at {path}. Run with --collect first and browse the app with VITE_PROFILE=true.")
+        sys.exit(1)
+    else:
+        print("No data file specified.")
+        sys.exit(1)
+
+    # Write report
+    out_path = path.parent / "react-render.json" if path.suffix != ".json" else path
+    out_path.write_text(json.dumps(report, indent=2))
+
+    # Print summary
+    print(f"\nReact Render Performance (sorted by total render time)")
+    print(f"{'Component':<40} {'Calls':>7} {'Total(ms)':>11} {'Max(ms)':>9}")
+    print("-" * 68)
+    for c in report["components"][:15]:
+        print(f"{c['id']:<40} {c['calls']:>7} {c['total_ms']:>11.2f} {c['max_ms']:>9.2f}")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/App.tsx scripts/perf/react/profiler_report.py
+git commit -m "feat(perf): add React Profiler integration with collection server"
+```
+
+---
+
+### Task 8: Main Orchestrator
+
+**Files:**
+- Create: `scripts/perf/run-all.py`
+
+- [ ] **Step 1: Write `scripts/perf/run-all.py`**
+
+```python
+#!/usr/bin/env python3
+"""Performance audit orchestrator — run all or selected subsystems."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.perf._common import (
+    today_dir, write_summary, read_summary, merge_json_files,
+    delta_table, check_thresholds, fail, REPORT_BASE,
+)
+
+BACKEND_TOOLS = ["db", "api-benchmark", "profile-hot"]
+FRONTEND_TOOLS = ["bundle-report", "lighthouse"]
+REACT_TOOLS = ["profiler"]
+
+PERF_DIR = Path(__file__).resolve().parent
+
+
+def run_tool(name: str, report_dir: Path) -> bool:
+    """Run a single tool. Returns True on success."""
+    tool_map = {
+        "db": [sys.executable, str(PERF_DIR / "backend" / "analyze_db.py")],
+        "api-benchmark": [
+            sys.executable, "-m", "pytest", str(PERF_DIR / "backend" / "benchmark_api.py"),
+            "--benchmark-only", "--benchmark-min-rounds=10",
+            f"--benchmark-json={report_dir}/api-benchmark.json",
+        ],
+        "profile-hot": [sys.executable, str(PERF_DIR / "backend" / "profile_hot.py")],
+        "bundle-report": ["node", str(PERF_DIR / "frontend" / "bundle_report.mjs")],
+        "lighthouse": ["node", str(PERF_DIR / "frontend" / "lighthouse.js")],
+        "profiler": [sys.executable, str(PERF_DIR / "react" / "profiler_report.py"), "--report",
+                     str(report_dir / "react-render.json")],
+    }
+
+    cmd = tool_map.get(name)
+    if not cmd:
+        print(f"Unknown tool: {name}")
+        return False
+
+    print(f"\n{'='*60}")
+    print(f"Running: {' '.join(cmd)}")
+    print(f"{'='*60}")
+    try:
+        subprocess.run(cmd, check=True, timeout=600)
+        return True
+    except subprocess.CalledProcessError:
+        print(f"Tool {name} failed with non-zero exit code")
+        return False
+    except subprocess.TimeoutExpired:
+        print(f"Tool {name} timed out")
+        return False
+
+
+def build_summary(report_dir: Path, results: dict) -> dict:
+    """Build a summary.json from tool outputs."""
+    summary: dict = {"date": report_dir.name, "results": results}
+
+    # DB summary
+    db_summary = report_dir / "db-summary.json"
+    if db_summary.exists():
+        summary["db"] = json.loads(db_summary.read_text())
+
+    # API benchmark summary
+    api_file = report_dir / "api-benchmark.json"
+    if api_file.exists():
+        try:
+            api_data = json.loads(api_file.read_text())
+            summary["api"] = {}
+            for bench in api_data.get("benchmarks", []):
+                name = bench["name"].replace("test_", "").replace("[", "_").replace("]", "")
+                summary["api"][name] = {
+                    "p50": bench["stats"]["median"],
+                    "p95": bench["stats"]["p95"],
+                    "p99": bench["stats"]["p99"],
+                    "ops": round(bench["stats"]["ops"], 2),
+                }
+        except Exception:
+            summary["api"] = {"error": "Failed to parse benchmark results"}
+
+    # Bundle summary
+    bundle_file = report_dir / "bundle-stats.json"
+    if bundle_file.exists():
+        try:
+            bundle_data = json.loads(bundle_file.read_text())
+            total_raw = sum(c["rawBytes"] for c in bundle_data.get("chunks", []))
+            total_gzip = sum(c["gzipBytes"] for c in bundle_data.get("chunks", []))
+            summary["bundle"] = {
+                "totalRawKB": round(total_raw / 1024, 1),
+                "totalGzipKB": round(total_gzip / 1024, 1),
+                "chunkCount": len(bundle_data.get("chunks", [])),
+                "warnings": bundle_data.get("warnings", []),
+            }
+        except Exception:
+            summary["bundle"] = {"error": "Failed to parse bundle stats"}
+
+    return summary
+
+
+def do_diff() -> None:
+    """Compare the two most recent report directories."""
+    dirs = sorted(
+        [d for d in REPORT_BASE.iterdir() if d.is_dir() and (d / "summary.json").exists()],
+        reverse=True,
+    )
+    if len(dirs) < 2:
+        fail("Need at least 2 report directories with summary.json for diff")
+
+    curr_dir, prev_dir = dirs[0], dirs[1]
+    prev = read_summary(prev_dir)
+    curr = read_summary(curr_dir)
+
+    metrics: list[tuple[str, str]] = []
+    # API metrics
+    for key in curr.get("api", {}):
+        for stat in ["p50", "p95", "p99"]:
+            metrics.append((f"API {key} {stat}", f"api.{key}.{stat}"))
+    # Bundle metrics
+    for key in ["totalRawKB", "totalGzipKB"]:
+        metrics.append((f"Bundle {key}", f"bundle.{key}"))
+
+    table = delta_table(prev, curr, metrics)
+    print(f"\nPerformance Delta: {prev_dir.name} → {curr_dir.name}")
+    print(table)
+
+    # Write diff to file
+    diff_path = curr_dir / "delta.txt"
+    diff_path.write_text(table)
+    print(f"\nDiff saved to {diff_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Scholar-Agent Performance Audit")
+    parser.add_argument("--target", choices=["backend", "frontend", "db", "all"], default="all")
+    parser.add_argument("--ci", action="store_true", help="JSON summary output, exit non-zero on threshold violation")
+    parser.add_argument("--diff", action="store_true", help="Compare two most recent reports")
+    parser.add_argument("--threshold", help="Comma-separated threshold rules, e.g. 'api.create_task_minimal.p95=800'")
+    args = parser.parse_args()
+
+    # Handle diff mode
+    if args.diff:
+        do_diff()
+        return
+
+    report_dir = today_dir()
+
+    # Determine tools to run
+    tools: list[str] = []
+    if args.target == "all":
+        tools = BACKEND_TOOLS + FRONTEND_TOOLS
+    elif args.target == "backend":
+        tools = BACKEND_TOOLS
+    elif args.target == "frontend":
+        tools = FRONTEND_TOOLS
+    elif args.target == "db":
+        tools = ["db"]
+
+    # Run tools
+    results: dict[str, bool] = {}
+    for tool in tools:
+        results[tool] = run_tool(tool, report_dir)
+
+    # Build and write summary
+    summary = build_summary(report_dir, results)
+    write_summary(report_dir, summary)
+
+    # Output
+    if args.ci:
+        print(json.dumps(summary, indent=2))
+    else:
+        success = sum(1 for v in results.values() if v)
+        total = len(results)
+        print(f"\n{'='*60}")
+        print(f"Performance audit complete: {success}/{total} tools passed")
+        print(f"Report directory: {report_dir}")
+
+    # Threshold check (CI or manual)
+    threshold_map: dict[str, float] = {}
+    if args.threshold:
+        for rule in args.threshold.split(","):
+            path, val = rule.split("=")
+            threshold_map[path] = float(val)
+
+    if threshold_map:
+        violations = check_thresholds(summary, threshold_map)
+        if violations:
+            for v in violations:
+                print(f"THRESHOLD VIOLATION: {v}")
+            if args.ci:
+                sys.exit(1)
+
+    # Exit non-zero if any tool failed
+    if not all(results.values()):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Test the orchestrator**
+
+```bash
+uv run python scripts/perf/run-all.py --target db
+```
+
+Expected: runs the database analyzer and prints a success message.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/perf/run-all.py
+git commit -m "feat(perf): add main orchestrator with --target, --ci, --diff, --threshold"
+```
+
+---
+
+### Task 9: CI Workflow
+
+**Files:**
+- Create: `.github/workflows/perf-check.yml`
+
+- [ ] **Step 1: Write `.github/workflows/perf-check.yml`**
+
+```yaml
+name: Performance Check
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Subsystem to audit'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - backend
+          - frontend
+          - db
+
+jobs:
+  perf-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Install py-spy
+        run: pip install py-spy
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install frontend deps
+        run: cd frontend && npm ci
+
+      - name: Start server
+        run: |
+          uv run ainrf serve --host 127.0.0.1 --port 8000 --state-root /tmp/ainrf-ci &
+          sleep 3
+
+      - name: Run performance audit
+        run: uv run python scripts/perf/run-all.py --target ${{ inputs.target }} --ci
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-report
+          path: .cache/perf-report/
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/perf-check.yml
+git commit -m "ci: add manual performance check workflow"
+```
+
+---
+
+### Task 10: Integration Verification
+
+- [ ] **Step 1: Full `--target db` run**
+
+```bash
+uv run python scripts/perf/run-all.py --target db
+```
+
+Verify: `.cache/perf-report/YYYY-MM-DD/db-index-report.md` and `db-summary.json` exist. No errors.
+
+- [ ] **Step 2: Full `--target frontend` run**
+
+```bash
+cd frontend && node ../scripts/perf/frontend/bundle_report.mjs
+```
+
+Verify: `bundle-treemap.html` and `bundle-stats.json` exist.
+
+- [ ] **Step 3: `--diff` mode with two reports**
+
+```bash
+# Create a second report by running db again (overwrites today's summary)
+uv run python scripts/perf/run-all.py --target db
+# Manually copy the first report to simulate having two days
+# Then run diff
+uv run python scripts/perf/run-all.py --diff
+```
+
+- [ ] **Step 4: Commit the .gitignore update**
+
+Add to `.gitignore`:
+```
+.cache/perf-report/
+```
+
+```bash
+git add .gitignore
+git commit -m "chore: gitignore perf report cache directory"
+```
+
+---
+
+## Verification Checklist
+
+1. `uv run python scripts/perf/run-all.py --target db` produces index report
+2. `uv run pytest scripts/perf/backend/benchmark_api.py --benchmark-only` runs API benchmarks (server must be running)
+3. `uv run python scripts/perf/run-all.py --target frontend` produces bundle treemap + stats
+4. `uv run python scripts/perf/run-all.py --diff` shows delta between two report dates
+5. `uv run python scripts/perf/run-all.py --ci --threshold api.create_task_minimal.p95=9999` exits 0 (or 1 if above threshold)
+6. GitHub Actions `perf-check` workflow appears in Actions tab (manual trigger only)

--- a/docs/superpowers/specs/2026-05-20-perf-audit-toolchain-design.md
+++ b/docs/superpowers/specs/2026-05-20-perf-audit-toolchain-design.md
@@ -1,0 +1,188 @@
+# Performance Audit Toolchain Design
+
+## 目标
+
+为 scholar-agent 项目建立可持续的全栈性能审计工具链，覆盖后端 API、数据库、前端 bundle、React 渲染四个维度。支持手动一键执行和 CI 调用，每次运行产出版本化报告，支持历史对比。
+
+## 优先级
+
+1. 用户感知延迟 > 2. 资源效率 > 3. 开发者体验
+
+## 工具链架构
+
+```
+scripts/perf/
+├── run-all.py          # 主入口：一键跑全栈，或按 --target 选择子系统
+├── _common.py          # 共享工具：计时、报告格式化、路径解析
+├── backend/
+│   ├── benchmark_api.py    # pytest-benchmark 测试套件
+│   ├── profile_hot.py      # py-spy 采样脚本
+│   └── analyze_db.py       # SQLite EXPLAIN QUERY PLAN 索引检查
+├── frontend/
+│   ├── lighthouse.js       # lhci 配置 + 自定义收集脚本
+│   └── bundle_report.mjs   # rollup-plugin-visualizer 包装 + 异常扫描
+├── react/
+│   └── profiler_report.py  # 解析 React.Profiler 导出数据
+└── reports/
+    └── (gitignored)        # .cache/perf-report/ 软链接到此
+```
+
+### 设计原则
+
+- 每个子工具可独立运行，也可通过 `run-all.py` 一键聚合
+- 所有报告输出到 `.cache/perf-report/YYYY-MM-DD/`
+- 每次执行覆盖同日报告，保留不同日期的历史对比
+- `--ci` 模式输出 JSON 摘要，默认模式输出终端彩色表格 + HTML 报告
+
+---
+
+## 后端性能测量
+
+### API 延迟基准 (`backend/benchmark_api.py`)
+
+使用 `pytest-benchmark` 对每个路由测量 p50/p95/p99 延迟。
+
+覆盖端点分组：
+
+| 组 | 端点 | 关注指标 |
+|------|------|------|
+| 认证 | `/auth/login`, `/auth/register`, `/auth/refresh` | bcrypt 哈希、JWT 签发延迟 |
+| 项目 | `/projects`, `/projects/{id}/tasks`, `/projects/{id}/task-edges` | 列表查询、索引退化 |
+| 任务创建 | `POST /tasks` | 端到端延迟（schema 写入 + 引擎启动） |
+| 文件 | `/files/read`, `/files/list` | 大文件 I/O、目录枚举 |
+| WebSocket | `/terminal/attach` | 连接建立延迟 |
+| 会话 | `/sessions`, `/sessions/{id}/attempts` | 历史查询性能 |
+
+每端点 3 轮 × 50 次调用，产出 `api-benchmark.json`。
+
+### 热点函数采样 (`backend/profile_hot.py`)
+
+向运行中的服务进程 attach `py-spy`，采样 30 秒：
+
+```bash
+py-spy record -o .cache/perf-report/YYYY-MM-DD/flamegraph.svg \
+  --pid $(cat .ainrf/server.pid) --duration 30
+```
+
+采样窗口内用预置 curl 脚本触发典型负载（创建 task、浏览 files、打开 terminal）。产出 `flamegraph.svg`。
+
+### 数据库查询分析 (`backend/analyze_db.py`)
+
+对每个 `.sqlite3` 文件：
+1. 读取所有表 schema，检查每列是否有索引
+2. 对核心查询运行 `EXPLAIN QUERY PLAN`，标记全表扫描
+3. 产出一份缺失索引报告 `db-index-report.md`
+
+---
+
+## 前端性能测量
+
+### Bundle 分析 (`frontend/bundle_report.mjs`)
+
+Vite 构建时注入 `rollup-plugin-visualizer`，产出：
+- `bundle-treemap.html` — 交互式模块大小树状图
+- `bundle-stats.json` — 各 chunk 原始大小 / gzip 大小
+
+自定义检查规则（构建后扫描）：
+- 任一 chunk > 500KB → 警告
+- 重复模块跨 chunk（去重失败）
+- 未 tree-shaken 的全量导出
+
+### 首屏加载 (`frontend/lighthouse.js`)
+
+使用 `lhci` CLI 对关键页面审计：
+
+```bash
+lhci collect --url http://localhost:5173/login
+lhci collect --url http://localhost:5173/projects
+lhci collect --url http://localhost:5173/tasks
+lhci assert --preset=recommended
+```
+
+产出 `lighthouse.json`（FCP / LCP / TBT / CLS）。
+
+### React 渲染性能 (`react/profiler_report.py`)
+
+在 `App.tsx` 中预置 `<React.Profiler>`（仅 `VITE_PROFILE=true` 时激活），收集每个路由页面的挂载耗时、更新耗时、渲染提交次数。通过 `performance.measure` API 收集数据并 post 到本地收集端点，产出 `react-render.json`。
+
+---
+
+## 执行方式
+
+### 手动执行
+
+```bash
+# 全栈一键测量
+uv run python scripts/perf/run-all.py
+
+# 单独跑某个子系统
+uv run python scripts/perf/run-all.py --target backend
+uv run python scripts/perf/run-all.py --target frontend
+uv run python scripts/perf/run-all.py --target db
+
+# 对比最新两次报告
+uv run python scripts/perf/run-all.py --diff
+```
+
+### CI 调用
+
+```bash
+uv run python scripts/perf/run-all.py --ci --threshold backend=800ms frontend=2s
+```
+
+- `--ci`：产出 JSON 摘要，退出码表示是否超阈值
+- `--threshold`：各子系统退化红线（可选，超阈值退出码非 0）
+- CI workflow 为手动触发（`workflow_dispatch`），不强制集成到 CI/CD 流水线
+
+---
+
+## 报告输出结构
+
+```
+.cache/perf-report/2026-05-20/
+├── summary.json          # 全栈汇总（供 --diff 历史对比）
+├── api-benchmark.json    # API 延迟 p50/p95/p99 数据
+├── flamegraph.svg        # py-spy 热点采样
+├── db-index-report.md    # 数据库索引分析与建议
+├── bundle-stats.json     # bundle chunk 大小
+├── bundle-treemap.html   # 交互式树状图
+├── lighthouse.json       # Lighthouse FCP/LCP/TBT 分数
+└── react-render.json     # React 组件渲染耗时排行
+```
+
+### 历史对比
+
+`--diff` 模式自动对比最近两次不同日期的 `summary.json`，输出各指标的 delta 百分比表：
+
+```
+Metric                        2026-05-19    2026-05-20    Delta
+────────────────────────────────────────────────────────────────
+API login p50                 12.3ms        14.1ms        +14.6%
+API create_task p95           840ms         920ms         +9.5%
+Bundle main chunk (gzip)      78KB          82KB          +5.1%
+Lighthouse LCP (projects)     1.8s          1.6s          -11.1%
+```
+
+---
+
+## 新建依赖
+
+### Python (pyproject.toml)
+- `pytest-benchmark` — API 微基准
+- `py-spy` — 采样 profiler（系统级安装：`pip install py-spy` 或 `cargo install py-spy`）
+
+### Node (frontend/package.json devDependencies)
+- `rollup-plugin-visualizer` — bundle 分析（已有 `vite-bundle-visualizer` 备选）
+- `@lhci/cli` — Lighthouse 审计
+
+### 系统
+- `py-spy` 需要 Linux perf 权限（`echo 0 > /proc/sys/kernel/perf_event_paranoid` 或 `CAP_SYS_ADMIN`）
+
+---
+
+## 验证
+
+1. `uv run python scripts/perf/run-all.py --target db` 产出索引报告
+2. `uv run python scripts/perf/run-all.py --target backend` 启动服务 → 跑 benchmark → 产出 flamegraph
+3. `cd frontend && npm run build` 后 `node scripts/perf/frontend/bundle_report.mjs` 产出 treemap
+4. `cd frontend && VITE_PROFILE=true npm run dev` 后加载页面，验证 React profiler 数据收集

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+frontend/.cache/

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,5 +1,6 @@
 # Logs
 logs
+/.cache/
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@lhci/cli": "^0.15.1",
         "@tailwindcss/vite": "^4.2.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
@@ -1226,6 +1227,62 @@
         }
       }
     },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.2",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/icu-skeleton-parser": "1.8.16",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1328,6 +1385,290 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lhci/cli": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@lhci/cli/-/cli-0.15.1.tgz",
+      "integrity": "sha512-yhC0oXnXqGHYy1xl4D8YqaydMZ/khFAnXGY/o2m/J3PqPa/D0nj3V6TLoH02oVMFeEF2AQim7UbmdXMiXx2tOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@lhci/utils": "0.15.1",
+        "chrome-launcher": "^0.13.4",
+        "compression": "^1.7.4",
+        "debug": "^4.3.1",
+        "express": "^4.17.1",
+        "inquirer": "^6.3.1",
+        "isomorphic-fetch": "^3.0.0",
+        "lighthouse": "12.6.1",
+        "lighthouse-logger": "1.2.0",
+        "open": "^7.1.0",
+        "proxy-agent": "^6.4.0",
+        "tmp": "^0.1.0",
+        "uuid": "^8.3.1",
+        "yargs": "^15.4.1",
+        "yargs-parser": "^13.1.2"
+      },
+      "bin": {
+        "lhci": "src/cli.js"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lhci/cli/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@lhci/cli/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/yargs/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@lhci/utils": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@lhci/utils/-/utils-0.15.1.tgz",
+      "integrity": "sha512-WclJnUQJeOMY271JSuaOjCv/aA0pgvuHZS29NFNdIeI14id8eiFsjith85EGKYhljgoQhJ2SiW4PsVfFiakNNw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "isomorphic-fetch": "^3.0.0",
+        "js-yaml": "^3.13.1",
+        "lighthouse": "12.6.1",
+        "tree-kill": "^1.2.1"
+      }
+    },
+    "node_modules/@lhci/utils/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@lhci/utils/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@monaco-editor/loader": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
@@ -1378,6 +1719,149 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@paulirish/trace_engine": {
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@paulirish/trace_engine/-/trace_engine-0.0.53.tgz",
+      "integrity": "sha512-PUl/vlfo08Oj804VI5nDPeSk9vyslnBlVzDDwFt8SUVxY8+KdGMkra/vrXjEEHe8gb7+RqVTfOIlGw0nyrEelA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "legacy-javascript": "latest",
+        "third-party-web": "latest"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
+      "integrity": "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.4",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@puppeteer/browsers/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -2049,6 +2533,91 @@
         "win32"
       ]
     },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.120.4.tgz",
+      "integrity": "sha512-Fz5+4XCg3akeoFK+K7g+d7HqGMjmnLoY2eJlpONJmaeT9pXY7yfUyXKZMmMajdE2LxxKJgQ2YKvSCaGVamTjHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.120.4.tgz",
+      "integrity": "sha512-TXu3Q5kKiq8db9OXGkWyXUbIxMMuttB5vJ031yolOl5T/B69JRyAoKuojLBjRv1XX583gS1rSSoX8YXX7ATFGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/integrations": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.120.4.tgz",
+      "integrity": "sha512-kkBTLk053XlhDCg7OkBQTIMF4puqFibeRO3E3YiVc4PGLnocXMaVpOSCkMqAc1k1kZ09UgGi8DxfQhnFEjUkpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4",
+        "localforage": "^1.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.120.4.tgz",
+      "integrity": "sha512-qq3wZAXXj2SRWhqErnGCSJKUhPSlZ+RGnCZjhfjHpP49KNpcd9YdPTIUsFMgeyjdh6Ew6aVCv23g1hTP0CHpYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.120.4",
+        "@sentry/core": "7.120.4",
+        "@sentry/integrations": "7.120.4",
+        "@sentry/types": "7.120.4",
+        "@sentry/utils": "7.120.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.120.4.tgz",
+      "integrity": "sha512-cUq2hSSe6/qrU6oZsEP4InMI5VVdD86aypE+ENrQ6eZEVLTCYm1w6XhW1NvIu3UuWh7gZec4a9J7AFpYxki88Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "7.120.4",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.120.4.tgz",
+      "integrity": "sha512-zCKpyDIWKHwtervNK2ZlaK8mMV7gVUijAgFeJStH+CU/imcdquizV3pFLlSQYRswG+Lbyd6CT/LGRh3IbtkCFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.120.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -2449,6 +3018,13 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2585,6 +3161,17 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.0",
@@ -3045,6 +3632,30 @@
         "d3-zoom": "^3.0.0"
       }
     },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3095,13 +3706,32 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3139,6 +3769,13 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3147,6 +3784,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/autoprefixer": {
@@ -3185,12 +3835,134 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
+      "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.16",
@@ -3204,6 +3976,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -3213,6 +3995,48 @@
       "dependencies": {
         "require-from-string": "^2.0.2"
       }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
@@ -3258,6 +4082,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -3274,6 +4108,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -3284,10 +4128,51 @@
         "node": ">=8"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3348,6 +4233,13 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -3358,11 +4250,109 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chrome-launcher": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.13.4.tgz",
+      "integrity": "sha512-nnzXiDbGKjDSK6t2I+35OAPBy5Pw/39bgkb/ZAFwMhwJbdYBp6aH+vW28ZgtjdU890Q7D+3wN/tB8N66q5Gi2A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^1.0.5",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^1.0.0",
+        "mkdirp": "^0.5.3",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "node_modules/chrome-launcher/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/chrome-launcher/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chrome-launcher/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/chromium-bidi/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/classcat": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
       "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
       "license": "MIT"
+    },
+    "node_modules/cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/cliui": {
       "version": "9.0.1",
@@ -3399,12 +4389,102 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/configstore": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dot-prop": "^5.2.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^3.0.0",
+        "unique-string": "^2.0.0",
+        "write-file-atomic": "^3.0.0",
+        "xdg-basedir": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -3426,6 +4506,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3440,6 +4527,23 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/csp_evaluator": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/csp_evaluator/-/csp_evaluator-1.1.5.tgz",
+      "integrity": "sha512-EL/iN9etCTzw/fBnp0/uj0f5BOOGvZut2mzsiiBZ/FdT6gFQCKRO/tmcKOxn5drWZ2Ndm/xBb1SI4zwWbGtmIw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
@@ -3600,6 +4704,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/data-urls": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
@@ -3640,6 +4754,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/decimal.js": {
@@ -3709,6 +4833,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3717,6 +4866,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/detect-libc": {
@@ -3728,6 +4888,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1467305",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1467305.tgz",
+      "integrity": "sha512-LxwMLqBoPPGpMdRL4NkLFRNy3QLp6Uqa7GNp1v6JaBheop2QrB9Q7q0A/q/CYYP9sBfZdHOyszVx4gc9zyk7ow==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
@@ -3746,6 +4913,41 @@
         "@types/trusted-types": "^2.0.7"
       }
     },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.332",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.332.tgz",
@@ -3758,6 +4960,26 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
@@ -3773,6 +4995,33 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/enquirer/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/entities": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
@@ -3786,12 +5035,45 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -3844,6 +5126,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -3855,6 +5144,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint": {
@@ -3995,6 +5317,20 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -4051,6 +5387,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -4061,10 +5417,140 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/external-editor/node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4081,6 +5567,16 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -4100,6 +5596,29 @@
         }
       }
     },
+    "node_modules/figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/figures/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -4112,6 +5631,42 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -4151,6 +5706,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -4163,6 +5728,23 @@
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
       }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -4177,6 +5759,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gensync": {
@@ -4212,6 +5804,98 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -4238,6 +5922,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4253,6 +5950,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hermes-estree": {
@@ -4285,6 +6008,37 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-link-header": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.3.tgz",
+      "integrity": "sha512-3cZ0SRL8fb9MUlU3mKM61FcQvPfXx2dBrZW3Vbg5CXa8jFlK8OaEpePenLe1oEXQduhz8b0QjsqfS59QP4AJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -4313,6 +6067,19 @@
         "node": ">= 14"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4322,6 +6089,20 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/image-ssim": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/image-ssim/-/image-ssim-0.2.0.tgz",
+      "integrity": "sha512-W7+sO6/yhxy83L0G7xR8YAc5Z5QFtYEXXRV6EaE8tuYBZJnA3gVgp3q7X7muhLZVodeb9UfvjSbwt9VJwjIYAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -4360,6 +6141,231 @@
         "node": ">=8"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/inquirer": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.12",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/inquirer/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/inquirer/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/string-width/node_modules/ansi-regex": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/string-width/node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/inquirer/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.18",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-docker": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
@@ -4384,6 +6390,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -4431,10 +6447,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4461,6 +6494,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -4469,6 +6513,23 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/js-library-detector": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/js-library-detector/-/js-library-detector-6.7.0.tgz",
+      "integrity": "sha512-c80Qupofp43y4cJ7+8TTDN/AsDwLi5oOm/plBrWI+iQt485vKXCco+yVmOwEgdo9VOdsYTuV0UlTeetVPTriXA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/js-tokens": {
@@ -4588,6 +6649,13 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/legacy-javascript": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/legacy-javascript/-/legacy-javascript-0.0.1.tgz",
+      "integrity": "sha512-lPyntS4/aS7jpuvOlitZDFifBCb4W8L/3QU0PLbUTUj+zYah8rfVjYic88yG7ZKTxhS5h9iz7duT8oUXKszLhg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4600,6 +6668,312 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/lighthouse": {
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-12.6.1.tgz",
+      "integrity": "sha512-85WDkjcXAVdlFem9Y6SSxqoKiz/89UsDZhLpeLJIsJ4LlHxw047XTZhlFJmjYCB7K5S1erSBAf5cYLcfyNbH3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@paulirish/trace_engine": "0.0.53",
+        "@sentry/node": "^7.0.0",
+        "axe-core": "^4.10.3",
+        "chrome-launcher": "^1.2.0",
+        "configstore": "^5.0.1",
+        "csp_evaluator": "1.1.5",
+        "devtools-protocol": "0.0.1467305",
+        "enquirer": "^2.3.6",
+        "http-link-header": "^1.1.1",
+        "intl-messageformat": "^10.5.3",
+        "jpeg-js": "^0.4.4",
+        "js-library-detector": "^6.7.0",
+        "lighthouse-logger": "^2.0.1",
+        "lighthouse-stack-packs": "1.12.2",
+        "lodash-es": "^4.17.21",
+        "lookup-closest-locale": "6.2.0",
+        "metaviewport-parser": "0.3.0",
+        "open": "^8.4.0",
+        "parse-cache-control": "1.0.1",
+        "puppeteer-core": "^24.10.0",
+        "robots-parser": "^3.0.1",
+        "semver": "^5.3.0",
+        "speedline-core": "^1.4.3",
+        "third-party-web": "^0.26.6",
+        "tldts-icann": "^6.1.16",
+        "ws": "^7.0.0",
+        "yargs": "^17.3.1",
+        "yargs-parser": "^21.0.0"
+      },
+      "bin": {
+        "chrome-debug": "core/scripts/manual-chrome-launcher.js",
+        "lighthouse": "cli/index.js",
+        "smokehouse": "cli/test/smokehouse/frontends/smokehouse-bin.js"
+      },
+      "engines": {
+        "node": ">=18.20"
+      }
+    },
+    "node_modules/lighthouse-logger": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.2.0.tgz",
+      "integrity": "sha512-wzUvdIeJZhRsG6gpZfmSCfysaxNEr43i+QT+Hie94wvHDKFLi4n7C2GqZ4sTC+PH5b5iktmXJvU87rWvhP3lHw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^2.6.8",
+        "marky": "^1.2.0"
+      }
+    },
+    "node_modules/lighthouse-logger/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/lighthouse-logger/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lighthouse-stack-packs": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-stack-packs/-/lighthouse-stack-packs-1.12.2.tgz",
+      "integrity": "sha512-Ug8feS/A+92TMTCK6yHYLwaFMuelK/hAKRMdldYkMNwv+d9PtWxjXEg6rwKtsUXTADajhdrhXyuNCJ5/sfmPFw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/lighthouse/node_modules/chrome-launcher": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.1.tgz",
+      "integrity": "sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^2.0.1"
+      },
+      "bin": {
+        "print-chrome-path": "bin/print-chrome-path.cjs"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/lighthouse/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/lighthouse/node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lighthouse/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lighthouse/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lighthouse/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lighthouse/node_modules/lighthouse-logger": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-2.0.2.tgz",
+      "integrity": "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "marky": "^1.2.2"
+      }
+    },
+    "node_modules/lighthouse/node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lighthouse/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/lighthouse/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lighthouse/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lighthouse/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/lighthouse/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lighthouse/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/lighthouse/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lightningcss": {
@@ -4875,6 +7249,16 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lie": "3.1.1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4891,10 +7275,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lookup-closest-locale": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/lookup-closest-locale/-/lookup-closest-locale-6.2.0.tgz",
+      "integrity": "sha512-/c2kL+Vnp1jnV6K6RpDTHK3dgg0Tu2VVp+elEiJpjfS1UyY7AjOYHohRug6wT0OpoX2qFgNORndE9RqesfVxWQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4945,6 +7350,22 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/marked": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
@@ -4957,12 +7378,122 @@
         "node": ">= 18"
       }
     },
+    "node_modules/marky": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+      "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/metaviewport-parser": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/metaviewport-parser/-/metaviewport-parser-0.3.0.tgz",
+      "integrity": "sha512-EoYJ8xfjQ6kpe9VbVHvZTZHiOl4HL1Z18CrZ+qahvLXT7ZO4YTC2JMyt5FaUp9JJp6J4Ybb/z7IsCXZt86/QkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
@@ -4987,6 +7518,36 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/monaco-editor": {
       "version": "0.55.1",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
@@ -5003,6 +7564,13 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -5029,11 +7597,136 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "license": "MIT"
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/open": {
       "version": "11.0.0",
@@ -5074,6 +7767,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -5106,6 +7809,50 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5118,6 +7865,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
+      "dev": true
     },
     "node_modules/parse5": {
       "version": "8.0.1",
@@ -5132,6 +7885,16 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5140,6 +7903,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -5151,6 +7924,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -5168,6 +7948,13 @@
       "engines": {
         "node": ">= 14.16"
       }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5275,6 +8062,78 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5283,6 +8142,74 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.43.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.1.tgz",
+      "integrity": "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.13.2",
+        "chromium-bidi": "14.0.0",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1608973",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.1",
+        "ws": "^8.20.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/devtools-protocol": {
+      "version": "0.0.1608973",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
+      "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/react": {
@@ -5366,6 +8293,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -5376,6 +8313,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -5384,6 +8328,47 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/robots-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-3.0.1.tgz",
+      "integrity": "sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/rolldown": {
@@ -5516,6 +8501,64 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/rxjs/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -5545,11 +8588,83 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -5574,12 +8689,136 @@
         "node": ">=8"
       }
     },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/source-map": {
       "version": "0.7.6",
@@ -5600,6 +8839,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/speedline-core": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/speedline-core/-/speedline-core-1.4.3.tgz",
+      "integrity": "sha512-DI7/OuAUD+GMpR6dmu8lliO2Wg5zfeh+/xsdyJZCzd8o5JgFUjCeLsBDuZjIQJdwXS3J0L/uZYrELKYqx+PXog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "image-ssim": "^0.2.0",
+        "jpeg-js": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -5613,12 +8874,34 @@
       "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
       "license": "MIT"
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
     },
     "node_modules/string-width": {
       "version": "7.2.0",
@@ -5753,6 +9036,68 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/third-party-web": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.26.7.tgz",
+      "integrity": "sha512-buUzX4sXC4efFX6xg2bw6/eZsCUh8qQwSavC4D9HpONMFlRbcHhD8Je5qwYdCpViR6q0qla2wPP+t91a2vgolg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -5834,6 +9179,60 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tldts-icann": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-6.1.86.tgz",
+      "integrity": "sha512-NFxmRT2lAEMcCOBgeZ0NuM0zsK/xgmNajnY6n4S1mwAKocft2s2ise1O3nQxrH3c+uY6hgHUV9GGNVp7tUE4Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      }
+    },
+    "node_modules/tldts-icann/node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rimraf": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tmp/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
@@ -5858,6 +9257,16 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/ts-api-utils": {
@@ -5890,6 +9299,37 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
       }
     },
     "node_modules/typescript": {
@@ -5936,6 +9376,29 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unique-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crypto-random-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -5984,6 +9447,37 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vite": {
@@ -6350,6 +9844,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -6359,6 +9860,13 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",
@@ -6399,6 +9907,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
@@ -6458,6 +9973,26 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
     "node_modules/ws": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
@@ -6495,6 +10030,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/xml-name-validator": {
@@ -6557,6 +10102,17 @@
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,6 +41,7 @@
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
         "jsdom": "^27.4.0",
+        "rollup-plugin-visualizer": "^7.0.1",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.58.0",
         "vite": "^8.0.4",
@@ -3257,6 +3258,22 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -3346,6 +3363,21 @@
       "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
       "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
       "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -3634,6 +3666,49 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3676,6 +3751,13 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.332.tgz",
       "integrity": "sha512-7OOtytmh/rINMLwaFTbcMVvYXO3AUm029X0LcyfYk0B557RlPkdpTpnH9+htMlfu5dKwOmT0+Zs2Aw+lnn6TeQ==",
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
@@ -4107,6 +4189,29 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -4255,6 +4360,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4278,12 +4399,60 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4866,6 +5035,27 @@
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "license": "MIT"
     },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5031,6 +5221,19 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -5269,6 +5472,50 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-visualizer": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-7.0.1.tgz",
+      "integrity": "sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "open": "^11.0.0",
+        "picomatch": "^4.0.2",
+        "source-map": "^0.7.4",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "rolldown": "1.x || ^1.0.0-beta || ^1.0.0-rc",
+        "rollup": "2.x || 3.x || 4.x"
+      },
+      "peerDependenciesMeta": {
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -5334,6 +5581,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5362,6 +5619,53 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -6123,6 +6427,37 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/ws": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
@@ -6145,6 +6480,23 @@
         }
       }
     },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -6162,12 +6514,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@lhci/cli": "^0.15.1",
     "@tailwindcss/vite": "^4.2.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,6 +46,7 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
     "jsdom": "^27.4.0",
+    "rollup-plugin-visualizer": "^7.0.1",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.58.0",
     "vite": "^8.0.4",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from 'react';
+import { lazy, Profiler, Suspense, type ProfilerOnRenderCallback } from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter, Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import { ErrorBoundary, Layout, ToastProvider } from './components/common';
@@ -23,6 +23,33 @@ const LoginPage = lazy(() => import('./pages/LoginPage'));
 const RegisterPage = lazy(() => import('./pages/RegisterPage'));
 
 const queryClient = createAppQueryClient();
+
+const PROFILER_ENABLED = import.meta.env.VITE_PROFILE === 'true';
+
+const profilerData: Array<{
+  id: string;
+  phase: string;
+  actualDuration: number;
+  baseDuration: number;
+  commitTime: number;
+}> = [];
+
+const onRender: ProfilerOnRenderCallback = (
+  id, phase, actualDuration, baseDuration, _startTime, commitTime,
+) => {
+  if (PROFILER_ENABLED) {
+    profilerData.push({ id, phase, actualDuration, baseDuration, commitTime });
+    // Keep only last 50 entries to bound memory
+    if (profilerData.length > 50) {
+      profilerData.splice(0, profilerData.length - 50);
+    }
+  }
+};
+
+// Expose profiler data to window for collection
+if (PROFILER_ENABLED && typeof window !== 'undefined') {
+  (window as unknown as Record<string, unknown>).__perfProfilerData = profilerData;
+}
 
 const defaultRoutePathById = {
   projects: '/projects',
@@ -101,7 +128,8 @@ function AppRoutes() {
     );
   }
 
-  return <AuthenticatedRoutes />;
+  const content = <AuthenticatedRoutes />;
+  return PROFILER_ENABLED ? <Profiler id="AppRoutes" onRender={onRender}>{content}</Profiler> : content;
 }
 
 function App() {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,11 +1,22 @@
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'vite'
+import { visualizer } from 'rollup-plugin-visualizer'
 import { sharedAinrfProxyConfig } from './vite.proxy'
 
 // https://vite.dev/config/
+const ANALYZE = process.env.VITE_BUNDLE_ANALYZE === 'true'
+
 const config = defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(),
+    ...(ANALYZE ? [visualizer({
+      open: false,
+      gzipSize: true,
+      brotliSize: true,
+      filename: '.cache/perf-report/bundle-treemap.html',
+      template: 'treemap',
+    })] : []),
+  ],
   build: {
     rollupOptions: {
       output: {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ ainrf = "ainrf.cli:main"
 dev = [
   "pre-commit>=4.3.0",
   "pytest>=8.4.2",
+  "pytest-benchmark>=5.1",
   "ruff>=0.12.11",
   "ty>=0.0.1a19",
 ]

--- a/scripts/perf/__init__.py
+++ b/scripts/perf/__init__.py
@@ -1,0 +1,1 @@
+"""Performance audit toolchain."""

--- a/scripts/perf/_common.py
+++ b/scripts/perf/_common.py
@@ -1,0 +1,103 @@
+"""Shared utilities for the performance audit toolchain."""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+REPORT_BASE = REPO_ROOT / ".cache" / "perf-report"
+
+
+def today_dir() -> Path:
+    """Return and create the dated report directory for today."""
+    date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    d = REPORT_BASE / date_str
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def read_summary(report_dir: Path) -> dict:
+    """Read summary.json from a report directory, returning {} if missing."""
+    path = report_dir / "summary.json"
+    if path.exists():
+        return json.loads(path.read_text())
+    return {}
+
+
+def write_summary(report_dir: Path, data: dict) -> None:
+    """Write summary.json to a report directory."""
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "summary.json").write_text(json.dumps(data, indent=2))
+
+
+def merge_json_files(dir_path: Path, glob_pattern: str) -> dict:
+    """Merge all JSON files matching glob_pattern into a single dict keyed by filename stem."""
+    merged: dict = {}
+    for f in sorted(dir_path.glob(glob_pattern)):
+        try:
+            merged[f.stem] = json.loads(f.read_text())
+        except (json.JSONDecodeError, OSError):
+            merged[f.stem] = {"error": f"Failed to parse {f.name}"}
+    return merged
+
+
+def delta_table(prev: dict, curr: dict, metrics: list[tuple[str, str]]) -> str:
+    """Build a terminal delta table comparing two summary dicts.
+
+    Args:
+        prev: Previous summary dict.
+        curr: Current summary dict.
+        metrics: List of (label, dotted_key_path) pairs, e.g. [("API login p50", "api.login.p50")].
+
+    Returns:
+        Formatted table string.
+    """
+    lines = [
+        f"{'Metric':<40} {'Previous':>12} {'Current':>12} {'Delta':>10}",
+        "-" * 74,
+    ]
+
+    def _get(d: dict, path: str):
+        keys = path.split(".")
+        v = d
+        for k in keys:
+            v = v.get(k, {}) if isinstance(v, dict) else {}
+        return v if isinstance(v, (int, float)) else None
+
+    for label, key_path in metrics:
+        pv = _get(prev, key_path)
+        cv = _get(curr, key_path)
+        if pv is not None and cv is not None and pv != 0:
+            delta = (cv - pv) / pv * 100
+            pv_str = f"{pv:.1f}"
+            cv_str = f"{cv:.1f}"
+            delta_str = f"{delta:+.1f}%"
+        else:
+            pv_str = str(pv) if pv is not None else "N/A"
+            cv_str = str(cv) if cv is not None else "N/A"
+            delta_str = "N/A"
+        lines.append(f"{label:<40} {pv_str:>12} {cv_str:>12} {delta_str:>10}")
+
+    return "\n".join(lines)
+
+
+def check_thresholds(summary: dict, thresholds: dict[str, float]) -> list[str]:
+    """Check summary values against thresholds. Returns list of violation messages."""
+    violations: list[str] = []
+    for path, limit in thresholds.items():
+        keys = path.split(".")
+        v = summary
+        for k in keys:
+            v = v.get(k, {}) if isinstance(v, dict) else 0
+        if isinstance(v, (int, float)) and v > limit:
+            violations.append(f"{path}: {v:.1f} > {limit:.1f}")
+    return violations
+
+
+def fail(msg: str) -> None:
+    """Print error and exit non-zero."""
+    print(f"ERROR: {msg}", file=sys.stderr)
+    sys.exit(1)

--- a/scripts/perf/backend/__init__.py
+++ b/scripts/perf/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend performance measurement tools."""

--- a/scripts/perf/backend/analyze_db.py
+++ b/scripts/perf/backend/analyze_db.py
@@ -1,0 +1,175 @@
+"""SQLite index analyzer — scans all project databases for missing indexes."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+STATE_ROOT = Path.home() / ".ainrf" / "runtime"
+
+# Column names frequently used in WHERE / JOIN / ORDER BY clauses that should be indexed
+WATCH_COLUMNS: dict[str, list[str]] = {
+    "task_harness_tasks": ["project_id", "status", "environment_id", "workspace_id", "session_id", "owner_user_id", "created_at"],
+    "task_harness_output_events": ["kind"],
+    "task_harness_edges": ["project_id", "source_task_id", "target_task_id"],
+    "managed_tasks": ["environment_id", "status", "task_id"],
+    "task_terminal_bindings": ["status", "ownership_user_id", "agent_write_state"],
+    "task_sessions": ["project_id", "status", "created_at"],
+    "task_attempts": ["session_id", "parent_attempt_id", "status"],
+    "users": ["username", "status"],
+    "refresh_tokens": ["user_id", "expires_at"],
+}
+
+# Queries to EXPLAIN — these represent common API call paths
+EXPLAIN_QUERIES: dict[str, list[tuple[str, str]]] = {
+    "task_harness.sqlite3": [
+        ("list_tasks_by_project",
+         "SELECT task_id FROM task_harness_tasks WHERE project_id = ? AND status != 'archived'"),
+        ("list_output_by_task",
+         "SELECT seq, kind, data FROM task_harness_output_events WHERE task_id = ? AND seq > ?"),
+        ("list_edges_by_project",
+         "SELECT edge_id, source_task_id, target_task_id FROM task_harness_edges WHERE project_id = ?"),
+    ],
+    "auth.sqlite3": [
+        ("login_lookup", "SELECT id, password_hash, role, status FROM users WHERE username = ?"),
+        ("list_collaborators", "SELECT user_id, role FROM project_collaborators WHERE project_id = ?"),
+    ],
+    "sessions.sqlite3": [
+        ("list_sessions",
+         "SELECT session_id, title, status FROM task_sessions WHERE project_id = ? ORDER BY created_at DESC"),
+        ("list_attempts",
+         "SELECT attempt_id, status, started_at FROM task_attempts WHERE session_id = ? ORDER BY started_at DESC"),
+    ],
+}
+
+
+def get_tables(conn: sqlite3.Connection) -> list[str]:
+    return [r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")]
+
+
+def get_indexed_columns(conn: sqlite3.Connection) -> dict[str, set[str]]:
+    """Return {table_name: {indexed_column_names}} including PK columns."""
+    indexed: dict[str, set[str]] = {}
+    for (tbl,) in conn.execute("SELECT name FROM sqlite_master WHERE type='table'"):
+        cols: set[str] = set()
+        # Primary key columns
+        for row in conn.execute(f"PRAGMA table_info('{tbl}')"):
+            if row[5]:  # pk flag
+                cols.add(row[1])
+        # Index columns
+        for idx_row in conn.execute(f"PRAGMA index_list('{tbl}')"):
+            for info_row in conn.execute(f"PRAGMA index_info('{idx_row[1]}')"):
+                cols.add(info_row[2])
+        indexed[tbl] = cols
+    return indexed
+
+
+def analyze_db(db_path: Path) -> dict:
+    """Analyze a single SQLite database. Returns findings dict."""
+    findings: dict[str, list[str]] = {"missing_indexes": [], "full_scans": [], "tables": []}
+    if not db_path.exists():
+        findings["error"] = f"Database not found: {db_path}"
+        return findings
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        tables = get_tables(conn)
+        findings["tables"] = tables
+        indexed = get_indexed_columns(conn)
+
+        # Check missing indexes
+        for tbl in tables:
+            if tbl in WATCH_COLUMNS:
+                need = WATCH_COLUMNS[tbl]
+                have = indexed.get(tbl, set())
+                for col in need:
+                    if col not in have:
+                        findings["missing_indexes"].append(f"{db_path.name}:{tbl}.{col}")
+
+        # EXPLAIN QUERY PLAN for core queries
+        db_key = db_path.name
+        if db_key in EXPLAIN_QUERIES:
+            for label, query in EXPLAIN_QUERIES[db_key]:
+                try:
+                    placeholders = query.count("?")
+                    params = ("?",) * placeholders if placeholders else ()
+                    plan_rows = conn.execute(f"EXPLAIN QUERY PLAN {query}", params).fetchall()
+                    plan_text = "\n".join(
+                        f"  {r[0]}|{r[1]}|{r[2]}|{r[3]}"
+                        for r in plan_rows
+                    )
+                    if "SCAN TABLE" in plan_text:
+                        findings["full_scans"].append(f"{db_key}:{label}\n{plan_text}")
+                except Exception as exc:
+                    findings["full_scans"].append(f"{db_key}:{label} (EXPLAIN failed: {exc})")
+
+    finally:
+        conn.close()
+
+    return findings
+
+
+def render_report(all_findings: dict[str, dict]) -> str:
+    """Render findings as a Markdown report."""
+    lines = ["# Database Index Analysis Report", "", f"**State root:** `{STATE_ROOT}`", ""]
+    for db_key in sorted(all_findings.keys()):
+        findings = all_findings[db_key]
+        lines.append(f"## {db_key}")
+        lines.append("")
+        if "error" in findings:
+            lines.append(f"**Error:** {findings['error']}")
+            lines.append("")
+            continue
+
+        lines.append(f"Tables: {', '.join(findings.get('tables', []))}")
+        lines.append("")
+
+        missing = findings.get("missing_indexes", [])
+        if missing:
+            lines.append("### Missing Indexes")
+            for m in sorted(missing):
+                parts = m.split(":")
+                lines.append(f"- `{parts[0]}` — `{parts[1]}` (missing index on `{parts[1].split('.')[1]}`)")
+            lines.append("")
+
+        scans = findings.get("full_scans", [])
+        if scans:
+            lines.append("### Full Table Scans Detected")
+            for s in scans:
+                lines.append(f"```\n{s}\n```")
+            lines.append("")
+        else:
+            lines.append("*No full table scans detected in core queries.*")
+            lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    from scripts.perf._common import today_dir
+
+    report_dir = today_dir()
+    all_findings: dict[str, dict] = {}
+
+    for db_name in ["auth.sqlite3", "sessions.sqlite3", "task_harness.sqlite3", "terminal_state.sqlite3"]:
+        db_path = STATE_ROOT / db_name
+        all_findings[db_name] = analyze_db(db_path)
+
+    report_md = render_report(all_findings)
+    out_path = report_dir / "db-index-report.md"
+    out_path.write_text(report_md)
+    print(f"Database index report written to {out_path}")
+
+    # Also write JSON summary for the master summary
+    (report_dir / "db-summary.json").write_text(json.dumps({
+        db: {
+            "missing_index_count": len(f.get("missing_indexes", [])),
+            "full_scan_count": len(f.get("full_scans", [])),
+        }
+        for db, f in all_findings.items()
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/perf/backend/benchmark_api.py
+++ b/scripts/perf/backend/benchmark_api.py
@@ -1,0 +1,138 @@
+"""API latency benchmarks using pytest-benchmark.
+
+Usage:
+  uv run pytest scripts/perf/backend/benchmark_api.py --benchmark-only
+  uv run pytest scripts/perf/backend/benchmark_api.py --benchmark-only --benchmark-min-rounds=10 --benchmark-max-time=0.5 --benchmark-json=.cache/perf-report/YYYY-MM-DD/api-benchmark.json
+
+Requires a running AINRF server at http://127.0.0.1:8000 with a test admin user.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+
+BASE_URL = os.environ.get("AINRF_PERF_BASE_URL", "http://127.0.0.1:8000")
+ADMIN_USER = os.environ.get("AINRF_PERF_USER", "perf-admin")
+ADMIN_PASS = os.environ.get("AINRF_PERF_PASS", "perf-test-pass")
+
+
+def _admin_headers(client: httpx.Client) -> dict[str, str]:
+    """Get admin JWT headers, registering the perf user if needed."""
+    # Try login
+    resp = client.post(
+        f"{BASE_URL}/auth/login",
+        json={"username": ADMIN_USER, "password": ADMIN_PASS},
+    )
+    if resp.status_code == 200:
+        token = resp.json()["access_token"]
+        return {"Authorization": f"Bearer {token}"}
+
+    # Register then try again
+    client.post(
+        f"{BASE_URL}/auth/register",
+        json={
+            "username": ADMIN_USER,
+            "display_name": "Perf Admin",
+            "password": ADMIN_PASS,
+        },
+    )
+    resp2 = client.post(
+        f"{BASE_URL}/auth/login",
+        json={"username": ADMIN_USER, "password": ADMIN_PASS},
+    )
+    if resp2.status_code != 200:
+        pytest.skip(
+            f"Cannot authenticate perf user (server may require manual activation): {resp2.text}"
+        )
+    return {"Authorization": f"Bearer {resp2.json()['access_token']}"}
+
+
+@pytest.fixture(scope="module")
+def client():
+    with httpx.Client(base_url=BASE_URL, timeout=30) as c:
+        yield c
+
+
+@pytest.fixture(scope="module")
+def auth_headers(client):
+    return _admin_headers(client)
+
+
+# --- Auth endpoints ---
+
+
+def test_login(benchmark, client):
+    benchmark(
+        lambda: client.post(
+            f"{BASE_URL}/auth/login",
+            json={"username": ADMIN_USER, "password": ADMIN_PASS},
+        )
+    )
+
+
+def test_auth_me(benchmark, client, auth_headers):
+    benchmark(lambda: client.get(f"{BASE_URL}/auth/me", headers=auth_headers))
+
+
+# --- Project endpoints ---
+
+
+def test_list_projects(benchmark, client, auth_headers):
+    benchmark(lambda: client.get(f"{BASE_URL}/projects", headers=auth_headers))
+
+
+def test_list_tasks(benchmark, client, auth_headers):
+    benchmark(
+        lambda: client.get(
+            f"{BASE_URL}/projects/default/tasks", headers=auth_headers
+        )
+    )
+
+
+def test_list_task_edges(benchmark, client, auth_headers):
+    benchmark(
+        lambda: client.get(
+            f"{BASE_URL}/projects/default/task-edges", headers=auth_headers
+        )
+    )
+
+
+# --- File endpoints ---
+
+
+def test_file_list(benchmark, client, auth_headers):
+    benchmark(
+        lambda: client.get(
+            f"{BASE_URL}/files/list?environment_id=env-localhost&path=/",
+            headers=auth_headers,
+        )
+    )
+
+
+# --- Session endpoints ---
+
+
+def test_list_sessions(benchmark, client, auth_headers):
+    benchmark(lambda: client.get(f"{BASE_URL}/sessions", headers=auth_headers))
+
+
+# --- Task creation ---
+
+
+def test_create_task_minimal(benchmark, client, auth_headers):
+    payload = {
+        "project_id": "default",
+        "workspace_id": "workspace-default",
+        "environment_id": "env-localhost",
+        "task_profile": "claude-code",
+        "task_input": "benchmark",
+        "title": "perf-bench-task",
+    }
+    benchmark(
+        lambda: client.post(
+            f"{BASE_URL}/tasks", json=payload, headers=auth_headers
+        )
+    )

--- a/scripts/perf/backend/profile_hot.py
+++ b/scripts/perf/backend/profile_hot.py
@@ -1,0 +1,111 @@
+"""py-spy hotspot profiler helper.
+
+Attaches py-spy to the running AINRF server process and triggers a
+representative workload, producing a flamegraph SVG.
+
+Requires: py-spy (pip install py-spy)
+Requires: A running AINRF server with a known PID.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+BASE_URL = os.environ.get("AINRF_PERF_BASE_URL", "http://127.0.0.1:8000")
+STATE_ROOT = Path(os.environ.get("AINRF_STATE_ROOT", Path.home() / ".ainrf"))
+PID_FILE = STATE_ROOT / "server.pid"
+DURATION = int(os.environ.get("AINRF_PERF_PROFILE_DURATION", "30"))
+
+WORKLOAD_SCRIPT = r'''
+import httpx, os, sys, json
+BASE = os.environ.get("AINRF_PERF_BASE_URL", "http://127.0.0.1:8000")
+
+def get_token():
+    r = httpx.post(f"{BASE}/auth/login", json={"username": "perf-admin", "password": "perf-test-pass"})
+    if r.status_code != 200:
+        r = httpx.post(f"{BASE}/auth/register", json={"username": "perf-admin", "display_name": "Perf Admin", "password": "perf-test-pass"})
+        r = httpx.post(f"{BASE}/auth/login", json={"username": "perf-admin", "password": "perf-test-pass"})
+        if r.status_code != 200:
+            print(f"Cannot authenticate: {r.status_code} {r.text}", file=sys.stderr)
+            sys.exit(1)
+    return r.json()["access_token"]
+
+token = get_token()
+h = {"Authorization": f"Bearer {token}"}
+
+for i in range(10):
+    httpx.get(f"{BASE}/projects/default/tasks", headers=h)
+    httpx.get(f"{BASE}/files/list?environment_id=env-localhost&path=/", headers=h)
+    httpx.post(f"{BASE}/tasks", json={
+        "project_id": "default", "workspace_id": "workspace-default",
+        "environment_id": "env-localhost", "task_profile": "claude-code",
+        "task_input": "perf profile", "title": f"perf-profile-{i}",
+    }, headers=h)
+'''
+
+
+def find_pid() -> int:
+    """Find the AINRF server PID from PID file or process search."""
+    if PID_FILE.exists():
+        return int(PID_FILE.read_text().strip())
+
+    # Fallback: find the uvicorn process
+    result = subprocess.run(
+        ["pgrep", "-f", "ainrf serve"],
+        capture_output=True, text=True,
+    )
+    if result.returncode == 0:
+        return int(result.stdout.strip().split('\n')[0])
+
+    print("ERROR: Cannot find AINRF server process. Start the server first or set AINRF_STATE_ROOT.", file=sys.stderr)
+    sys.exit(1)
+
+
+def main() -> None:
+    from scripts.perf._common import today_dir
+
+    report_dir = today_dir()
+
+    # Check py-spy is available
+    try:
+        subprocess.run(["py-spy", "--version"], capture_output=True, check=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        print("ERROR: py-spy not found. Install with: pip install py-spy", file=sys.stderr)
+        sys.exit(1)
+
+    pid = find_pid()
+    flamegraph_path = report_dir / "flamegraph.svg"
+
+    print(f"Profiling PID {pid} for {DURATION}s...")
+
+    # Start py-spy in background
+    py_spy = subprocess.Popen([
+        "py-spy", "record",
+        "-o", str(flamegraph_path),
+        "--pid", str(pid),
+        "--duration", str(DURATION),
+        "--native",
+    ])
+
+    # Give py-spy a moment to attach, then trigger workload
+    time.sleep(1)
+    print("Triggering workload...")
+    try:
+        subprocess.run(
+            [sys.executable, "-c", WORKLOAD_SCRIPT],
+            timeout=DURATION + 10,
+        )
+    except subprocess.TimeoutExpired:
+        print("Workload timed out (this may be OK)")
+
+    # Wait for py-spy to finish
+    py_spy.wait(timeout=DURATION + 15)
+    print(f"Flamegraph written to {flamegraph_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/perf/frontend/bundle_report.mjs
+++ b/scripts/perf/frontend/bundle_report.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Bundle report script — builds the frontend with the visualizer plugin
+ * and scans output chunks for size anomalies.
+ */
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync, mkdirSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { gzipSync, brotliCompressSync } from 'node:zlib';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FRONTEND_DIR = join(__dirname, '..', '..', '..', 'frontend');
+const REPO_ROOT = join(__dirname, '..', '..', '..');
+const REPORT_DIR = join(REPO_ROOT, '.cache', 'perf-report', new Date().toISOString().slice(0, 10));
+const CHUNK_WARN_KB = 500;
+
+function run(cmd, cwd = FRONTEND_DIR) {
+    console.log(`> ${cmd}`);
+    execSync(cmd, { cwd, encoding: 'utf-8', stdio: 'inherit' });
+}
+
+// Step 1: Build with visualizer enabled
+console.log('Building frontend with bundle analyzer...');
+run('VITE_BUNDLE_ANALYZE=true npx vite build');
+
+// Move the treemap to the report dir
+const treemapSrc = join(FRONTEND_DIR, '.cache', 'perf-report', 'bundle-treemap.html');
+const treemapDst = join(REPORT_DIR, 'bundle-treemap.html');
+mkdirSync(REPORT_DIR, { recursive: true });
+try {
+    const treemapHtml = readFileSync(treemapSrc, 'utf-8');
+    writeFileSync(treemapDst, treemapHtml);
+    console.log(`Treemap written to ${treemapDst}`);
+} catch {
+    console.warn('Warning: treemap HTML not found at expected path.');
+}
+
+// Step 2: Collect chunk stats
+const distDir = join(FRONTEND_DIR, 'dist');
+
+function collectStats(dir) {
+    const chunks = [];
+    const entries = readdirSync(dir, { recursive: true, withFileTypes: true });
+    for (const entry of entries) {
+        const fp = join(entry.parentPath || entry.path, entry.name);
+        if (entry.isFile() && (entry.name.endsWith('.js') || entry.name.endsWith('.css'))) {
+            const raw = readFileSync(fp);
+            chunks.push({
+                file: fp.replace(distDir + '/', ''),
+                rawBytes: raw.length,
+                gzipBytes: gzipSync(raw).length,
+                brotliBytes: brotliCompressSync(raw).length,
+            });
+        }
+    }
+    return chunks;
+}
+
+const chunks = collectStats(distDir);
+chunks.sort((a, b) => b.rawBytes - a.rawBytes);
+
+// Step 3: Scan for anomalies
+const warnings = [];
+for (const c of chunks) {
+    if (c.gzipBytes > CHUNK_WARN_KB * 1024) {
+        warnings.push(`LARGE CHUNK: ${c.file} — ${(c.gzipBytes / 1024).toFixed(1)}KB gzip`);
+    }
+}
+
+// Simple duplicate detection
+const filenames = chunks.map(c => c.file.split('/').pop() || c.file);
+for (let i = 0; i < filenames.length; i++) {
+    for (let j = i + 1; j < filenames.length; j++) {
+        if (filenames[i] === filenames[j]) {
+            warnings.push(`DUPLICATE MODULE: ${chunks[i].file} and ${chunks[j].file} may be the same module in different chunks`);
+        }
+    }
+}
+
+const statsPath = join(REPORT_DIR, 'bundle-stats.json');
+writeFileSync(statsPath, JSON.stringify({ chunks, warnings }, null, 2));
+
+if (warnings.length > 0) {
+    console.log('\n=== Bundle Warnings ===');
+    for (const w of warnings) console.log(`  ⚠  ${w}`);
+} else {
+    console.log('\nNo bundle size warnings.');
+}
+
+console.log(`\nBundle stats written to ${statsPath}`);

--- a/scripts/perf/frontend/lighthouse.js
+++ b/scripts/perf/frontend/lighthouse.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Lighthouse CI audit for key pages.
+ *
+ * Usage: node scripts/perf/frontend/lighthouse.js [--url=http://localhost:5173]
+ *
+ * Requires a running frontend dev server.
+ */
+import { execSync } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..', '..');
+const REPORT_DIR = join(REPO_ROOT, '.cache', 'perf-report', new Date().toISOString().slice(0, 10));
+
+const BASE_URL = process.argv.find(a => a.startsWith('--url='))?.split('=')[1] || 'http://localhost:5173';
+const PAGES = ['/login', '/projects', '/tasks'];
+
+function run(cmd) {
+    console.log(`> ${cmd}`);
+    execSync(cmd, { encoding: 'utf-8', stdio: 'inherit' });
+}
+
+mkdirSync(REPORT_DIR, { recursive: true });
+
+let allPassed = true;
+
+for (const page of PAGES) {
+    const url = `${BASE_URL}${page}`;
+    console.log(`\n=== Auditing ${url} ===`);
+    const slug = page.replace(/^\//, '').replace(/\//g, '-') || 'home';
+
+    try {
+        run(`npx lhci collect --url="${url}" --numberOfRuns=3`);
+        run(`npx lhci assert --preset=recommended --includePassed=false || true`);
+    } catch (e) {
+        console.warn(`Warning: Lighthouse audit had issues for ${url}: ${e.message}`);
+        allPassed = false;
+    }
+}
+
+console.log(`\nLighthouse audit complete. Outputs in ${REPORT_DIR}`);
+process.exit(allPassed ? 0 : 0); // Never fail on audit — just report
+}

--- a/scripts/perf/react/profiler_report.py
+++ b/scripts/perf/react/profiler_report.py
@@ -1,0 +1,120 @@
+"""React Profiler data collection and reporting.
+
+Starts a tiny HTTP server that the frontend can POST profiler data to,
+then generates a ranked component render-time report.
+
+Usage:
+  # Start the collection server
+  python scripts/perf/react/profiler_report.py --collect
+
+  # Generate report from collected data
+  python scripts/perf/react/profiler_report.py --report .cache/perf-report/YYYY-MM-DD/react-render.json
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+COLLECTED: list[dict] = []
+
+
+class CollectHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        path = urlparse(self.path).path
+        if path == "/collect":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length)
+            data = json.loads(body)
+            COLLECTED.extend(data if isinstance(data, list) else [data])
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(json.dumps({"received": len(COLLECTED)}).encode())
+        elif path == "/dump":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(json.dumps(COLLECTED).encode())
+        elif path == "/reset":
+            COLLECTED.clear()
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"{}")
+
+    def do_GET(self):
+        if urlparse(self.path).path == "/dump":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(json.dumps(COLLECTED).encode())
+
+    def log_message(self, format, *args):
+        pass  # Suppress request logs
+
+
+def start_collect_server(port: int = 9876) -> None:
+    print(f"Profiler collection server listening on http://127.0.0.1:{port}")
+    server = HTTPServer(("127.0.0.1", port), CollectHandler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    server.server_close()
+
+
+def generate_report(data: list[dict]) -> dict:
+    """Aggregate profiler data by component id."""
+    by_id: dict[str, dict] = {}
+    for entry in data:
+        cid = entry.get("id", "unknown")
+        if cid not in by_id:
+            by_id[cid] = {"id": cid, "calls": 0, "total_ms": 0.0, "max_ms": 0.0}
+        by_id[cid]["calls"] += 1
+        by_id[cid]["total_ms"] += entry.get("actualDuration", 0)
+        by_id[cid]["max_ms"] = max(by_id[cid]["max_ms"], entry.get("actualDuration", 0))
+
+    ranked = sorted(by_id.values(), key=lambda x: x["total_ms"], reverse=True)
+    return {
+        "components": ranked,
+        "total_entries": len(data),
+        "total_duration_ms": sum(d.get("actualDuration", 0) for d in data),
+    }
+
+
+def main() -> None:
+    from scripts.perf._common import today_dir
+
+    if "--collect" in sys.argv:
+        start_collect_server()
+        return
+
+    if "--report" in sys.argv:
+        idx = sys.argv.index("--report")
+        path = Path(sys.argv[idx + 1]) if idx + 1 < len(sys.argv) else None
+    else:
+        path = today_dir() / "react-render.json"
+
+    if path and path.exists():
+        data = json.loads(path.read_text())
+        report = generate_report(data)
+    elif path:
+        print(f"No data file at {path}. Run with --collect first and browse the app with VITE_PROFILE=true.")
+        sys.exit(1)
+    else:
+        print("No data file specified.")
+        sys.exit(1)
+
+    out_path = path.parent / "react-render.json" if path.suffix != ".json" else path
+    out_path.write_text(json.dumps(report, indent=2))
+
+    print(f"\nReact Render Performance (sorted by total render time)")
+    print(f"{'Component':<40} {'Calls':>7} {'Total(ms)':>11} {'Max(ms)':>9}")
+    print("-" * 68)
+    for c in report["components"][:15]:
+        print(f"{c['id']:<40} {c['calls']:>7} {c['total_ms']:>11.2f} {c['max_ms']:>9.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/perf/run-all.py
+++ b/scripts/perf/run-all.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Performance audit orchestrator — run all or selected subsystems."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Ensure the repo root is on sys.path so that "scripts.perf._common" resolves.
+# Python 3.14+ no longer adds the current directory to sys.path by default.
+_repo_root = Path(__file__).resolve().parent.parent.parent
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+from scripts.perf._common import (
+    today_dir, write_summary, read_summary, delta_table,
+    check_thresholds, fail, REPORT_BASE,
+)
+
+BACKEND_TOOLS = ["db", "api-benchmark", "profile-hot"]
+FRONTEND_TOOLS = ["bundle-report", "lighthouse"]
+REACT_TOOLS = ["profiler"]
+
+PERF_DIR = Path(__file__).resolve().parent
+
+TOOL_MAP: dict[str, list[str]] = {
+    "db": [sys.executable, str(PERF_DIR / "backend" / "analyze_db.py")],
+    "api-benchmark": [
+        sys.executable, "-m", "pytest", str(PERF_DIR / "backend" / "benchmark_api.py"),
+        "--benchmark-only", "--benchmark-min-rounds=10",
+    ],
+    "profile-hot": [sys.executable, str(PERF_DIR / "backend" / "profile_hot.py")],
+    "bundle-report": ["node", str(PERF_DIR / "frontend" / "bundle_report.mjs")],
+    "lighthouse": ["node", str(PERF_DIR / "frontend" / "lighthouse.js")],
+    "profiler": [sys.executable, str(PERF_DIR / "react" / "profiler_report.py"), "--report"],
+}
+
+
+def run_tool(name: str, report_dir: Path) -> bool:
+    """Run a single tool. Returns True on success."""
+    cmd = TOOL_MAP.get(name)
+    if not cmd:
+        print(f"Unknown tool: {name}")
+        return False
+
+    # For tools that need the report dir path appended
+    if name == "api-benchmark":
+        cmd = cmd + [f"--benchmark-json={report_dir}/api-benchmark.json"]
+    elif name == "profiler":
+        cmd = cmd + [str(report_dir / "react-render.json")]
+
+    print(f"\n{'='*60}")
+    print(f"Running: {' '.join(cmd)}")
+    print(f"{'='*60}")
+    env = dict(os.environ)
+    env.setdefault("PYTHONPATH", "")
+    repo_root = str(Path(__file__).resolve().parent.parent.parent)
+    if repo_root not in env["PYTHONPATH"]:
+        env["PYTHONPATH"] = f"{repo_root}:{env['PYTHONPATH']}" if env["PYTHONPATH"] else repo_root
+    try:
+        subprocess.run(cmd, check=True, timeout=600, env=env)
+        return True
+    except subprocess.CalledProcessError:
+        print(f"Tool '{name}' failed with non-zero exit code")
+        return False
+    except subprocess.TimeoutExpired:
+        print(f"Tool '{name}' timed out (10 min)")
+        return False
+
+
+def build_summary(report_dir: Path, results: dict[str, bool]) -> dict:
+    """Build a summary.json from tool outputs."""
+    summary: dict = {"date": report_dir.name, "results": results}
+
+    # DB summary
+    db_summary = report_dir / "db-summary.json"
+    if db_summary.exists():
+        summary["db"] = json.loads(db_summary.read_text())
+
+    # API benchmark summary
+    api_file = report_dir / "api-benchmark.json"
+    if api_file.exists():
+        try:
+            api_data = json.loads(api_file.read_text())
+            summary["api"] = {}
+            for bench in api_data.get("benchmarks", []):
+                name = bench["name"].replace("test_", "").replace("[", "_").replace("]", "")
+                summary["api"][name] = {
+                    "p50": bench["stats"]["median"],
+                    "p95": bench["stats"]["p95"],
+                    "p99": bench["stats"]["p99"],
+                    "ops": round(bench["stats"]["ops"], 2),
+                }
+        except Exception:
+            summary["api"] = {"error": "Failed to parse benchmark results"}
+
+    # Bundle summary
+    bundle_file = report_dir / "bundle-stats.json"
+    if bundle_file.exists():
+        try:
+            bundle_data = json.loads(bundle_file.read_text())
+            total_raw = sum(c["rawBytes"] for c in bundle_data.get("chunks", []))
+            total_gzip = sum(c["gzipBytes"] for c in bundle_data.get("chunks", []))
+            summary["bundle"] = {
+                "totalRawKB": round(total_raw / 1024, 1),
+                "totalGzipKB": round(total_gzip / 1024, 1),
+                "chunkCount": len(bundle_data.get("chunks", [])),
+                "warnings": bundle_data.get("warnings", []),
+            }
+        except Exception:
+            summary["bundle"] = {"error": "Failed to parse bundle stats"}
+
+    return summary
+
+
+def do_diff() -> None:
+    """Compare the two most recent report directories."""
+    dirs = sorted(
+        [d for d in REPORT_BASE.iterdir() if d.is_dir() and (d / "summary.json").exists()],
+        reverse=True,
+    )
+    if len(dirs) < 2:
+        fail("Need at least 2 report directories with summary.json for diff")
+
+    curr_dir, prev_dir = dirs[0], dirs[1]
+    prev = read_summary(prev_dir)
+    curr = read_summary(curr_dir)
+
+    metrics: list[tuple[str, str]] = []
+    for key in curr.get("api", {}):
+        for stat in ["p50", "p95", "p99"]:
+            metrics.append((f"API {key} {stat}", f"api.{key}.{stat}"))
+    for key in ["totalRawKB", "totalGzipKB"]:
+        metrics.append((f"Bundle {key}", f"bundle.{key}"))
+
+    table = delta_table(prev, curr, metrics)
+    print(f"\nPerformance Delta: {prev_dir.name} -> {curr_dir.name}")
+    print(table)
+
+    diff_path = curr_dir / "delta.txt"
+    diff_path.write_text(table)
+    print(f"\nDelta saved to {diff_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Scholar-Agent Performance Audit")
+    parser.add_argument("--target", choices=["backend", "frontend", "db", "all"], default="all")
+    parser.add_argument("--ci", action="store_true",
+                        help="JSON summary output, exit non-zero on threshold violation")
+    parser.add_argument("--diff", action="store_true",
+                        help="Compare two most recent reports")
+    parser.add_argument("--threshold",
+                        help="Comma-separated threshold rules, e.g. 'api.create_task_minimal.p95=800'")
+    args = parser.parse_args()
+
+    if args.diff:
+        do_diff()
+        return
+
+    report_dir = today_dir()
+
+    tools: list[str] = []
+    if args.target == "all":
+        tools = BACKEND_TOOLS + FRONTEND_TOOLS
+    elif args.target == "backend":
+        tools = BACKEND_TOOLS
+    elif args.target == "frontend":
+        tools = FRONTEND_TOOLS
+    elif args.target == "db":
+        tools = ["db"]
+
+    results: dict[str, bool] = {}
+    for tool in tools:
+        results[tool] = run_tool(tool, report_dir)
+
+    summary = build_summary(report_dir, results)
+    write_summary(report_dir, summary)
+
+    if args.ci:
+        print(json.dumps(summary, indent=2))
+    else:
+        success = sum(1 for v in results.values() if v)
+        total = len(results)
+        print(f"\n{'='*60}")
+        print(f"Performance audit complete: {success}/{total} tools passed")
+        print(f"Report directory: {report_dir}")
+
+    threshold_map: dict[str, float] = {}
+    if args.threshold:
+        for rule in args.threshold.split(","):
+            path, val = rule.split("=")
+            threshold_map[path] = float(val)
+
+    if threshold_map:
+        violations = check_thresholds(summary, threshold_map)
+        if violations:
+            for v in violations:
+                print(f"THRESHOLD VIOLATION: {v}")
+            if args.ci:
+                sys.exit(1)
+
+    if not all(results.values()):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -37,6 +37,7 @@ dependencies = [
 dev = [
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-benchmark" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -65,6 +66,7 @@ requires-dist = [
 dev = [
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-benchmark", specifier = ">=5.1" },
     { name = "ruff", specifier = ">=0.12.11" },
     { name = "ty", specifier = ">=0.0.1a19" },
 ]
@@ -872,6 +874,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1012,6 +1023,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- **10 scripts** across `scripts/perf/` covering backend, frontend, and React performance measurement
- Main orchestrator `run-all.py` with `--target`, `--ci`, `--diff`, `--threshold` flags
- Backend: SQLite index analyzer, API latency benchmarks (pytest-benchmark), py-spy hotspot profiler
- Frontend: Bundle analyzer (rollup-plugin-visualizer), Lighthouse CI audit, React Profiler
- Manual CI workflow `.github/workflows/perf-check.yml`

## Test plan
- [x] `uv run python scripts/perf/run-all.py --target db` produces index report
- [x] All Python modules import cleanly
- [x] TypeScript `tsc -b` passes
- [x] Frontend builds with bundle analyzer enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)