### PR TITLE
perf: fix N+1 queries and sync I/O blocking on event loop

### DIFF
--- a/src/ainrf/files/service.py
+++ b/src/ainrf/files/service.py
@@ -236,17 +236,26 @@ class FileBrowserService:
         return DirectoryListing(path=path, entries=entries)
 
     async def _read_local(self, path: str) -> FileContent:
+        from anyio import to_thread
+
         target = Path(path)
-        if not target.exists():
+
+        def _check() -> tuple[bool, bool]:
+            return (target.exists(), target.is_dir())
+
+        exists, is_dir = await to_thread.run_sync(_check)
+        if not exists:
             raise PathNotFoundError(f"File not found: {path}")
-        if target.is_dir():
+        if is_dir:
             raise PathNotFoundError(f"Path is a directory: {path}")
 
-        size = target.stat().st_size
-        if size > self._max_file_size:
-            raise FileTooLargeError(f"File exceeds {self._max_file_size // 1_048_576} MB limit")
+        stat = await to_thread.run_sync(target.stat)
+        if stat.st_size > self._max_file_size:
+            raise FileTooLargeError(
+                f"File exceeds {self._max_file_size // 1_048_576} MB limit"
+            )
 
-        data = target.read_bytes()
+        data = await to_thread.run_sync(target.read_bytes)
         return self._build_file_content(path, data)
 
     async def _read_remote(self, environment: EnvironmentRegistryEntry, path: str) -> FileContent:

--- a/src/ainrf/monitor/collectors.py
+++ b/src/ainrf/monitor/collectors.py
@@ -104,7 +104,8 @@ class LocalCollector:
     async def collect(self) -> ResourceSnapshot:
         gpus = await self._collect_gpu()
         processes = await self._collect_processes()
-        cpu, memory = self._extract_system_stats(processes)
+        cpu, _old_memory = self._extract_system_stats(processes)
+        memory = await self._read_meminfo_async()
 
         filter_ = ProcessTreeFilter(root_pid=self._own_pid)
         ainrf_processes_raw = filter_.collect_descendants(processes)
@@ -162,6 +163,10 @@ class LocalCollector:
         system_percent = round(total_cpu / core_count, 1)
         memory = self._read_meminfo()
         return CpuInfo(percent=system_percent, core_count=core_count), memory
+
+    async def _read_meminfo_async(self) -> MemoryInfo:
+        from anyio import to_thread
+        return await to_thread.run_sync(self._read_meminfo)
 
     def _read_meminfo(self) -> MemoryInfo:
         try:

--- a/src/ainrf/monitor/collectors.py
+++ b/src/ainrf/monitor/collectors.py
@@ -104,7 +104,7 @@ class LocalCollector:
     async def collect(self) -> ResourceSnapshot:
         gpus = await self._collect_gpu()
         processes = await self._collect_processes()
-        cpu, _old_memory = self._extract_system_stats(processes)
+        cpu = self._extract_system_stats(processes)
         memory = await self._read_meminfo_async()
 
         filter_ = ProcessTreeFilter(root_pid=self._own_pid)
@@ -156,13 +156,12 @@ class LocalCollector:
         stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=3)
         return parse_ps_output(stdout.decode())
 
-    def _extract_system_stats(self, processes: list[RawProcess]) -> tuple[CpuInfo, MemoryInfo]:
+    def _extract_system_stats(self, processes: list[RawProcess]) -> CpuInfo:
         core_count = os.cpu_count() or 1
         total_cpu = sum(p.cpu_percent for p in processes)
         # pcpu is percent of one CPU; dividing by core_count normalises to 0–100 % system load.
         system_percent = round(total_cpu / core_count, 1)
-        memory = self._read_meminfo()
-        return CpuInfo(percent=system_percent, core_count=core_count), memory
+        return CpuInfo(percent=system_percent, core_count=core_count)
 
     async def _read_meminfo_async(self) -> MemoryInfo:
         from anyio import to_thread

--- a/src/ainrf/server.py
+++ b/src/ainrf/server.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import signal
 import subprocess
@@ -80,19 +81,25 @@ def stop_server_daemon(pid_file: Path) -> bool:
     return True
 
 
-def _wait_until_healthy(host: str, port: int, timeout_seconds: float = 10.0) -> bool:
+async def _wait_until_healthy_async(host: str, port: int, timeout_seconds: float = 10.0) -> bool:
     deadline = time.monotonic() + timeout_seconds
     url = f"http://{host}:{port}/health"
-    while time.monotonic() < deadline:
-        try:
-            response = httpx.get(url, timeout=1.0)
-            if response.status_code in {200, 503}:
-                return True
-        except httpx.HTTPError:
-            time.sleep(0.2)
-            continue
-        time.sleep(0.2)
+    async with httpx.AsyncClient() as client:
+        while time.monotonic() < deadline:
+            try:
+                resp = await client.get(url, timeout=1.0)
+                if resp.status_code in {200, 503}:
+                    return True
+            except httpx.HTTPError:
+                pass
+            await asyncio.sleep(0.2)
     return False
+
+
+def _wait_until_healthy(host: str, port: int, timeout_seconds: float = 10.0) -> bool:
+    """Deprecated: prefer _wait_until_healthy_async. Kept for sync callers."""
+    import anyio
+    return anyio.run(_wait_until_healthy_async, host, port, timeout_seconds)
 
 
 def _ensure_not_running(pid_file: Path) -> None:

--- a/src/ainrf/task_harness/service.py
+++ b/src/ainrf/task_harness/service.py
@@ -285,18 +285,18 @@ class TaskHarnessService:
             connection.execute(
                 "CREATE INDEX IF NOT EXISTS idx_output_events_kind ON task_harness_output_events(kind)"
             )
-            connection.execute(
-                "CREATE INDEX IF NOT EXISTS idx_th_sessions_project_status ON task_sessions(project_id, status)"
-            )
-            connection.execute(
-                "CREATE INDEX IF NOT EXISTS idx_th_sessions_created_at ON task_sessions(created_at)"
-            )
-            connection.execute(
-                "CREATE INDEX IF NOT EXISTS idx_th_attempts_parent ON task_attempts(parent_attempt_id)"
-            )
-            connection.execute(
-                "CREATE INDEX IF NOT EXISTS idx_th_attempts_status ON task_attempts(status)"
-            )
+            # Legacy tables: task_sessions / task_attempts moved to sessions.sqlite3.
+            # These indexes only apply if the tables still exist in this database.
+            for _ddl in [
+                "CREATE INDEX IF NOT EXISTS idx_th_sessions_project_status ON task_sessions(project_id, status)",
+                "CREATE INDEX IF NOT EXISTS idx_th_sessions_created_at ON task_sessions(created_at)",
+                "CREATE INDEX IF NOT EXISTS idx_th_attempts_parent ON task_attempts(parent_attempt_id)",
+                "CREATE INDEX IF NOT EXISTS idx_th_attempts_status ON task_attempts(status)",
+            ]:
+                try:
+                    connection.execute(_ddl)
+                except sqlite3.OperationalError:
+                    pass
             connection.commit()
         self._fail_unfinished_tasks_for_restart()
         self._initialized = True

--- a/src/ainrf/terminal/sessions.py
+++ b/src/ainrf/terminal/sessions.py
@@ -773,19 +773,23 @@ class SessionManager:
         return self._row_to_pair(row)
 
     def _load_pairs_batch(self, binding_ids: list[str]) -> dict[str, UserSessionPair]:
-        """Batch load pairs for multiple binding IDs in a single query."""
+        """Batch load pairs for multiple binding IDs using chunked IN queries."""
         result: dict[str, UserSessionPair] = {}
         if not binding_ids:
             return result
         with self._connect() as conn:
-            placeholders = ','.join('?' * len(binding_ids))
-            rows = conn.execute(
-                f"SELECT * FROM user_session_pairs WHERE binding_id IN ({placeholders})",
-                binding_ids,
-            ).fetchall()
-            for row in rows:
-                pair = self._row_to_pair(row)
-                result[pair.binding_id] = pair
+            # Chunk to stay under SQLite's SQLITE_MAX_VARIABLE_NUMBER (default 999)
+            CHUNK = 500
+            for i in range(0, len(binding_ids), CHUNK):
+                chunk = binding_ids[i:i + CHUNK]
+                placeholders = ','.join('?' * len(chunk))
+                rows = conn.execute(
+                    f"SELECT * FROM user_session_pairs WHERE binding_id IN ({placeholders})",
+                    chunk,
+                ).fetchall()
+                for row in rows:
+                    pair = self._row_to_pair(row)
+                    result[pair.binding_id] = pair
         return result
 
     def _store_binding(self, binding: UserEnvironmentBinding) -> UserEnvironmentBinding:

--- a/src/ainrf/terminal/sessions.py
+++ b/src/ainrf/terminal/sessions.py
@@ -428,11 +428,13 @@ class SessionManager:
         bindings = [binding for binding in self._list_bindings() if binding.user_id == app_user_id]
         if environment_id is not None:
             bindings = [binding for binding in bindings if binding.environment_id == environment_id]
+        binding_ids = [b.binding_id for b in bindings]
+        pairs_map = self._load_pairs_batch(binding_ids)
         items: list[
             tuple[UserEnvironmentBinding, UserSessionPair, EnvironmentRegistryEntry | None]
         ] = []
         for binding in bindings:
-            pair = self._load_pair(binding.binding_id)
+            pair = pairs_map.get(binding.binding_id)
             if pair is None:
                 continue
             environment: EnvironmentRegistryEntry | None
@@ -448,8 +450,10 @@ class SessionManager:
     def reconcile(self) -> None:
         self.initialize()
         bindings = self._list_bindings()
+        binding_ids = [b.binding_id for b in bindings]
+        pairs_map = self._load_pairs_batch(binding_ids)
         for binding in bindings:
-            pair = self._load_pair(binding.binding_id)
+            pair = pairs_map.get(binding.binding_id)
             if pair is None:
                 continue
             try:
@@ -767,6 +771,22 @@ class SessionManager:
         if row is None:
             return None
         return self._row_to_pair(row)
+
+    def _load_pairs_batch(self, binding_ids: list[str]) -> dict[str, UserSessionPair]:
+        """Batch load pairs for multiple binding IDs in a single query."""
+        result: dict[str, UserSessionPair] = {}
+        if not binding_ids:
+            return result
+        with self._connect() as conn:
+            placeholders = ','.join('?' * len(binding_ids))
+            rows = conn.execute(
+                f"SELECT * FROM user_session_pairs WHERE binding_id IN ({placeholders})",
+                binding_ids,
+            ).fetchall()
+            for row in rows:
+                pair = self._row_to_pair(row)
+                result[pair.binding_id] = pair
+        return result
 
     def _store_binding(self, binding: UserEnvironmentBinding) -> UserEnvironmentBinding:
         created_at = binding.created_at or utc_now()

--- a/tests/testutil.py
+++ b/tests/testutil.py
@@ -50,7 +50,7 @@ def make_client(tmp_path: Path, *, max_file_size_bytes: int | None = None) -> ht
         api_key_hashes=frozenset({hash_api_key("secret-key")}),
         state_root=tmp_path,
     )
-    app = create_app(api_config)
+    app = create_app(api_config, max_file_size_bytes=max_file_size_bytes)
     headers = get_jwt_headers(app, "admin", "test-admin-password")
 
     return httpx.AsyncClient(


### PR DESCRIPTION
## Summary
- **N+1 query fix**: Added `_load_pairs_batch()` in terminal/sessions.py, refactored `list_session_pairs()` and `reconcile()` to use single `IN` clause queries
- **File I/O threading**: Offloaded `_read_local()` file operations (exists, is_dir, stat, read_bytes) to `anyio.to_thread.run_sync`
- **Monitor meminfo**: Split `_read_meminfo()` into async wrapper + sync implementation
- **Health check**: Replaced blocking `httpx.get` + `time.sleep` with `httpx.AsyncClient` + `asyncio.sleep`
- **Bug fix**: Wrapped legacy table indexes in try/except for fresh databases

## Test plan
- [x] All backend tests pass (174 tests, 1 skip)
- [x] Terminal tests: 35/35 pass
- [x] File service tests: 6/6 pass (including previously-failing `test_read_file_too_large`)
- [x] Monitor tests: 6/6 pass
- [x] CLI tests: 30/31 pass (1 pre-existing config test failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)