### PR TITLE
docs(ainrf): refresh documentation to match current code baseline

### DIFF
--- a/docs/ainrf/auth.md
+++ b/docs/ainrf/auth.md
@@ -1,0 +1,157 @@
+---
+aliases:
+  - AINRF 认证与授权
+  - AINRF Authentication
+  - auth
+tags:
+  - ainrf
+  - auth
+  - docs
+  - obsidian-note
+source_repo: scholar-agent
+source_path: docs/ainrf/auth.md
+---
+
+# 认证与授权
+
+> [!abstract]
+> AINRF 使用 JWT Bearer Token 认证机制，支持用户注册审批、角色权限、环境授权与项目协作。
+
+## JWT 令牌
+
+认证使用 HS256 签名的 JWT 令牌：
+
+- **Access Token**：15 分钟有效期，携带 `sub`（用户 ID）、`username`、`role` 声明
+- **Refresh Token**：7 天有效期，以 SHA256 哈希存储在 SQLite 中（`refresh_tokens` 表）
+- 密钥来源优先级：环境变量 `AINRF_JWT_SECRET` > `~/.ainrf/jwt_secret` 文件 > 自动生成
+
+## API 端点
+
+| 方法    | 路径                      | 说明                           |
+| ------- | ------------------------- | ------------------------------ |
+| POST    | `/auth/register`          | 注册（状态为 `pending`）       |
+| POST    | `/auth/login`             | 登录，返回 access + refresh    |
+| POST    | `/auth/refresh`           | 使用 refresh token 刷新访问令牌 |
+| POST    | `/auth/logout`            | 登出（删除 refresh token）      |
+| GET     | `/auth/me`                | 获取当前用户信息               |
+| POST    | `/auth/change-password`   | 修改密码                       |
+
+### 注册
+
+```json
+POST /auth/register
+{
+  "username": "user1",
+  "display_name": "User One",
+  "password": "secure-password"
+}
+```
+
+返回 `201` 表示注册成功，状态为 `pending`，等待管理员审批。
+
+### 登录
+
+```json
+POST /auth/login
+{
+  "username": "user1",
+  "password": "secure-password"
+}
+```
+
+返回 access token、refresh token 和用户信息。`pending` 和 `disabled` 状态的用户无法登录。
+
+## 用户角色
+
+| 角色     | 权限范围                                                     |
+| -------- | ------------------------------------------------------------ |
+| `admin`  | 全部权限：用户管理、环境授权、项目管理、所有任务              |
+| `member` | 自有资源 + 协作项目资源，访问已被授权的环境 |
+
+## 用户状态
+
+```
+pending → active / disabled
+```
+
+- `pending`：新注册用户，等待管理员审批
+- `active`：正常可用
+- `disabled`：已被管理员禁用，无法登录
+
+## 首次 Admin 创建
+
+服务首次启动（`ainrf serve`）时，若数据库中无用户，自动创建初始管理员：
+
+- 用户名：`admin`
+- 密码：`admin`
+- 标记 `must_change_password = true`
+- 自动激活并授予 `localhost` 环境权限
+
+首次登录 `/auth/me` 返回 `must_change_password: true`，前端引导用户调用 `/auth/change-password` 修改密码。
+
+## Admin 面板
+
+管理员通过 `require_admin` 中间件保护的后台接口管理系统：
+
+| 方法   | 路径                                        | 说明               |
+| ------ | ------------------------------------------- | ------------------ |
+| GET    | `/admin/users`                              | 列出所有用户       |
+| PATCH  | `/admin/users/{user_id}`                    | 激活/禁用用户      |
+| PUT    | `/admin/users/{user_id}/password`           | 重置用户密码       |
+| PUT    | `/admin/environments/{env_id}/access`       | 授予环境访问权限   |
+| DELETE | `/admin/environments/{env_id}/access/{user_id}` | 撤销环境访问权限   |
+
+管理员可以：
+
+- 审批 `pending` 用户 → 设为 `active`
+- 禁用/启用用户账号
+- 重置任意用户密码
+- 授予或撤销用户对特定环境的访问权限
+- 设置用户的并发任务配额
+
+新激活的用户自动获得 `localhost` 环境的默认访问权限。
+
+## 环境授权
+
+每个用户可以独立授权访问不同环境，并限制并发任务数：
+
+```json
+PUT /admin/environments/env-localhost/access
+{
+  "user_id": "abc123",
+  "max_concurrent_tasks": 3
+}
+```
+
+环境授权记录存储在 `environment_access` 表中。
+
+## 项目协作者
+
+项目所有者可以添加协作者，并指定角色：
+
+| 角色     | 权限                            |
+| -------- | ------------------------------- |
+| `member` | 完全协作权限                    |
+| `viewer` | 只读权限                        |
+
+协作者管理通过如下 API：
+
+| 方法   | 路径                                        | 说明         |
+| ------ | ------------------------------------------- | ------------ |
+| GET    | `/projects/{project_id}/collaborators`      | 查看协作者   |
+| PUT    | `/projects/{project_id}/collaborators`      | 添加协作者   |
+| DELETE | `/projects/{project_id}/collaborators/{user_id}` | 移除协作者   |
+
+协作者记录存储在 `project_collaborators` 表中。
+
+## CLI 登录
+
+```bash
+ainrf login --server http://localhost:8000
+```
+
+交互式输入用户名和密码，成功后缓存 access token 和 refresh token 到本地文件，后续 API 请求自动携带 Authorization 头。
+
+## 配置参考
+
+参见 [[ainrf/index]] 了解整体配置入口。JWT 密钥和 API key 详见 [[settings]]。

--- a/docs/ainrf/cli.md
+++ b/docs/ainrf/cli.md
@@ -30,7 +30,7 @@ uv run ainrf serve --state-root ~/.ainrf
 - `--port`：监听端口（默认 `8000`）
 - `--state-root`：状态存储目录（默认 `~/.ainrf`）
 
-服务启动后会写入 PID 文件 (`~/.ainrf/server.pid`) 供 `stop` 命令使用。
+以 daemon 模式启动时写入 PID 文件 (`~/.ainrf/runtime/ainrf-api.pid`) 供 `stop` 命令使用。
 
 ## stop
 
@@ -42,11 +42,11 @@ uv run ainrf stop
 
 ## login
 
-通过 CLI 登录并缓存 JWT access token 到内存（供后续 CLI 调用使用）。
+通过 CLI 登录并缓存 JWT access token（交互式提示输入用户名和密码）。
 
 ```bash
 uv run ainrf login
-uv run ainrf login --username admin
+uv run ainrf login --server http://127.0.0.1:8000
 ```
 
 ## container
@@ -55,7 +55,6 @@ uv run ainrf login --username admin
 
 ```bash
 uv run ainrf container add
-uv run ainrf container list
 ```
 
 ## 关联笔记

--- a/docs/ainrf/cli.md
+++ b/docs/ainrf/cli.md
@@ -1,0 +1,64 @@
+---
+aliases: [CLI Reference, 命令行参考, cli]
+tags: [ainrf, cli]
+---
+
+# CLI 命令参考
+
+所有命令通过 `uv run ainrf <command>` 执行。添加 `--help` 查看完整参数。
+
+## onboard
+
+初始化本地状态目录 (`~/.ainrf`)、默认配置和工作区。
+
+```bash
+uv run ainrf onboard
+```
+
+## serve
+
+启动后端 API 服务（FastAPI + Uvicorn）。
+
+```bash
+uv run ainrf serve
+uv run ainrf serve --host 0.0.0.0 --port 8000
+uv run ainrf serve --state-root ~/.ainrf
+```
+
+参数：
+- `--host`：监听地址（默认 `127.0.0.1`）
+- `--port`：监听端口（默认 `8000`）
+- `--state-root`：状态存储目录（默认 `~/.ainrf`）
+
+服务启动后会写入 PID 文件 (`~/.ainrf/server.pid`) 供 `stop` 命令使用。
+
+## stop
+
+停止由 `serve` 启动的后台 daemon 进程。
+
+```bash
+uv run ainrf stop
+```
+
+## login
+
+通过 CLI 登录并缓存 JWT access token 到内存（供后续 CLI 调用使用）。
+
+```bash
+uv run ainrf login
+uv run ainrf login --username admin
+```
+
+## container
+
+管理可复用的容器/环境配置 profile。
+
+```bash
+uv run ainrf container add
+uv run ainrf container list
+```
+
+## 关联笔记
+
+- [[quickstart]] — 首次使用流程
+- [[webui]] — 浏览器访问方式

--- a/docs/ainrf/development.md
+++ b/docs/ainrf/development.md
@@ -1,0 +1,144 @@
+---
+aliases:
+  - 开发指南
+  - Development Guide
+  - development
+tags:
+  - ainrf
+  - development
+  - testing
+  - linting
+  - performance
+  - docs
+  - obsidian-note
+source_repo: scholar-agent
+source_path: docs/ainrf/development.md
+last_local_commit: workspace aggregate
+---
+
+# 开发指南
+
+> [!abstract]
+> AINRF 开发指南涵盖后端与前端测试、代码质量检查、性能审计和文档构建等日常开发任务。
+
+## 后端测试
+
+使用 `pytest` 运行后端测试套件：
+
+```bash
+# 运行全量测试
+uv run pytest
+
+# 运行单项测试（带详细输出）
+uv run pytest tests/test_file.py -v
+
+# 运行特定测试类或函数
+uv run pytest tests/test_file.py::TestClass::test_method -v
+```
+
+测试覆盖 CLI、API 路由、数据库操作、环境管理、终端会话和任务执行等核心模块。测试配置文件位于 `pyproject.toml`。
+
+## 后端 Lint / 格式化
+
+使用 Ruff 进行代码检查和自动格式化：
+
+```bash
+# 检查 lint 问题
+uv run ruff check .
+
+# 检查格式问题
+uv run ruff format --check .
+
+# 自动修复 lint 并格式化
+uv run ruff check --fix .
+uv run ruff format .
+```
+
+规则集和行长度（100）在 `pyproject.toml` 中配置。提交前 pre-commit hook 会自动运行 ruff。
+
+## 前端类型检查
+
+前端使用 TypeScript 项目引用（project references），必须以 `tsc -b` 方式运行：
+
+```bash
+cd frontend && node_modules/.bin/tsc -b
+```
+
+注意：不支持 `npx tsc -p tsconfig.app.json --noEmit` 或从仓库根目录运行 `tsc`。
+
+## 前端测试
+
+使用 Vitest 运行前端测试：
+
+```bash
+cd frontend && npm run test:run
+```
+
+测试覆盖组件渲染、用户交互、API 调用和路由行为。
+
+## 前端构建
+
+生产构建：
+
+```bash
+cd frontend && npm run build
+```
+
+构建产物输出至 `frontend/dist/`。
+
+## 性能审计
+
+性能审计脚本按目标分层组织在 `scripts/perf/` 目录下：
+
+```bash
+# 数据库索引审计
+uv run python scripts/perf/run-all.py --target db
+
+# API 基准测试
+uv run python scripts/perf/run-all.py --target backend
+
+# Bundle 分析
+uv run python scripts/perf/run-all.py --target frontend
+
+# 全栈审计（数据库 + backend + frontend）
+uv run python scripts/perf/run-all.py --target all
+```
+
+每个目标输出结构化报告，用于识别性能瓶颈和优化方向。
+
+## 文档构建与预览
+
+文档站基于 MkDocs（Material 主题），从 `docs/` 源文件构建：
+
+```bash
+# 完整构建（含 wikilink 验证）
+scripts/build.sh
+
+# 本地预览服务器
+scripts/serve.sh
+
+# 或直接通过 uv 运行
+uv run python scripts/build_html_notes.py build
+uv run python scripts/build_html_notes.py serve
+```
+
+构建脚本会验证所有 wikilinks 可解析，并在发现未解析引用时使构建失败。
+
+## Git 分支管理
+
+建议使用 git worktree 隔离特性开发工作区，避免频繁切换分支：
+
+```bash
+# 创建特性分支的工作区
+git worktree add .claude/worktrees/my-feature-branch my-feature-branch
+
+# 工作完成后清理
+git worktree remove .claude/worktrees/my-feature-branch
+git branch -d my-feature-branch
+```
+
+始终基于 `master` 分支创建新分支，提交前运行 lint 和测试。
+
+## 关联笔记
+
+- [[index]]

--- a/docs/ainrf/index.md
+++ b/docs/ainrf/index.md
@@ -1,148 +1,35 @@
 ---
-aliases:
-  - AINRF 使用文档
-  - AINRF Usage Guide
-tags:
-  - ainrf
-  - cli
-  - docs
-  - obsidian-note
+aliases: [AINRF 使用文档, AINRF Usage Guide]
+tags: [ainrf, docs, index]
 source_repo: scholar-agent
-source_path: docs/ainrf/index.md
-last_local_commit: workspace aggregate
 ---
+
 # AINRF 使用文档
 
 > [!abstract]
-> 本页记录当前仓库里已经存在并应作为默认主入口理解的 AINRF 产品面：CLI、后端 API、WebUI，以及围绕 environment / terminal / task / workspace browser 的运行时能力。文档站点构建与研究笔记预览仍然保留，但它们属于辅助维护流程，而不是仓库中心。
+> AINRF 是 scholar-agent 的核心前后端产品，提供 CLI、REST API、WebUI、Terminal、
+> Workspace Browser、任务引擎、多用户鉴权、性能监控等完整能力。本目录是用户文档入口。
 
-## AINRF 是什么
+## 核心子系统
 
-AINRF 是 `scholar-agent` 当前的核心前后端产品，实现面主要包括：
-
-- `src/ainrf/` 提供的可安装 CLI 与后端 API
-- `frontend/` 提供的 WebUI
-- `scripts/webui.sh` 驱动的前后端联合启动入口
-- environment 管理、keepalive personal terminal、managed task terminal 与受管 workspace browser
-
-研究笔记、外部项目调研和历史 RFC 仍保留在仓库中，但主要服务于设计参考和历史追溯。
-
-## 快速开始
-
-建议先确认 CLI 与主入口可见：
-
-```bash
-uv run ainrf --version
-uv run ainrf --help
-scripts/webui.sh
-```
-
-如果你的目标是直接使用当前产品面，优先顺序是：
-
-1. `scripts/webui.sh`
-2. `uv run ainrf serve`
-3. `uv run ainrf onboard`
-
-## WebUI 一键启动
-
-当前推荐入口：
-
-```bash
-scripts/webui.sh
-scripts/webui.sh dev
-scripts/webui.sh preview
-scripts/webui.sh dev --backend-public
-scripts/webui.sh preview --backend-public
-```
-
-这个入口会自动处理：
-
-- 默认 `UV_CACHE_DIR=/tmp/uv-cache`
-- 当前 shell 会话中的 `AINRF_WEBUI_API_KEY`
-- 当前 shell 会话中的 `AINRF_API_KEY_HASHES`
-- 后端 `ainrf serve` 与前端 dev/preview server 的联合启动
-
-默认暴露策略是：
-
-- 前端对内网可见：`0.0.0.0`
-- 后端默认仅本机：`127.0.0.1`
-
-浏览器通过前端同源代理访问 `/api`、`/code` 与 `/terminal`，不再需要手动管理浏览器侧 API key。
-
-## 启动 AINRF 服务
-
-当前底层后端入口是：
-
-```bash
-uv run ainrf serve
-uv run ainrf serve --help
-```
-
-这条路径主要适合：
-
-- 单独联调后端 API
-- 配合自定义前端或代理层调试
-- 验证 CLI / daemon / runtime 行为
-
-对大多数产品使用场景，仍应优先回到 `scripts/webui.sh`。
-
-## 首次初始化
-
-当前初始化入口是：
-
-```bash
-uv run ainrf onboard
-```
-
-它会准备服务运行所需的本地状态与配置。若 `serve` 提示缺少必要配置，应先完成 onboarding，而不是把缺失配置视为 notes/tooling 问题。
-
-## 其他 CLI 命令
-
-除初始化与服务启动外，当前还能直接看到的命令入口包括：
-
-```bash
-uv run ainrf container add
-uv run ainrf container add --help
-```
-
-它们用于写入 environment / container 相关配置项，是产品 runtime 的配置型入口。
-
-## 文档与知识库维护入口
-
-以下命令仍然保留，但应理解为维护辅助流程，而非 AINRF 主产品面：
-
-```bash
-scripts/serve.sh
-scripts/build.sh
-uv run python scripts/build_html_notes.py serve
-uv run python scripts/build_html_notes.py build
-```
-
-它们主要服务于 `docs/` 知识库与历史材料的本地预览/构建。
-
-## 常用开发与验证命令
-
-```bash
-uv run pytest
-uv run ruff check .
-uv run ruff format --check .
-```
-
-前端常用验证入口：
-
-```bash
-cd frontend && npm run lint
-cd frontend && npm run test:run
-cd frontend && npm run build
-```
-
-## 说明与边界
-
-- 本页优先描述当前已经交付的 AINRF 产品表面。
-- `docs/` 和 `ref-repos/` 为产品设计输入与历史追溯提供支持，但不再作为仓库默认主线。
-- 历史 RFC、路线图和更大运行时愿景，不应直接表述为当前已经交付的能力。
+| 子系统 | 说明 | 文档 |
+|--------|------|------|
+| 快速开始 | 安装、初始化、首次启动 | [[quickstart]] |
+| CLI | 命令行工具参考 | [[cli]] |
+| WebUI | 前端页面与布局 | [[webui]] |
+| 认证 | JWT 鉴权、用户角色、Admin 面板 | [[auth]] |
+| 项目管理 | Canvas DAG 可视化、任务创建与连线 | [[projects]] |
+| 终端 | Personal/Agent 会话、本地 bash、远程 SSH | [[terminal]] |
+| 工作区 | Workspace 管理、文件浏览器、Monaco 编辑器 | [[workspace]] |
+| 会话追踪 | Session/Attempt 链、成本与耗时统计 | [[sessions]] |
+| 时间线 | Gantt 图、任务时间分布可视化 | [[timeline]] |
+| 资源监控 | GPU/CPU/内存、进程树、环境检测 | [[resources]] |
+| 设置面板 | 通用设置、Admin 用户管理、环境授权 | [[settings]] |
+| 开发命令 | 测试、构建、lint、性能审计 | [[development]] |
 
 ## 关联笔记
 
 - [[index]]
-- 历史文档：`docs/archive/framework/`（V1 架构 RFC / roadmap）
+- 设计规范：`docs/superpowers/specs/`
+- 实施计划：`docs/superpowers/plans/`
+- 历史文档：`docs/archive/`

--- a/docs/ainrf/projects.md
+++ b/docs/ainrf/projects.md
@@ -1,0 +1,128 @@
+---
+aliases:
+  - AINRF 项目管理
+  - AINRF Projects
+  - projects
+tags:
+  - ainrf
+  - projects
+  - docs
+  - obsidian-note
+source_repo: scholar-agent
+source_path: docs/ainrf/projects.md
+---
+
+# 项目管理
+
+> [!abstract]
+> AINRF 以项目（Project）为任务组织单元，提供 ReactFlow 画布、任务节点、手动/自动连线和 dagre 布局。
+
+## 项目侧边栏
+
+左侧边栏显示项目列表，支持：
+
+- 项目选择与切换
+- 按名称搜索过滤
+- 创建新项目
+- 显示项目描述和更新时间
+
+API 端点：
+
+| 方法   | 路径                        | 说明           |
+| ------ | --------------------------- | -------------- |
+| GET    | `/projects`                 | 列出所有项目   |
+| POST   | `/projects`                 | 创建项目       |
+| GET    | `/projects/{project_id}`    | 读取项目详情   |
+| PATCH  | `/projects/{project_id}`    | 更新项目名称/描述/默认环境/默认工作区 |
+| DELETE | `/projects/{project_id}`    | 删除项目       |
+
+每个项目关联一组环境引用（`environment-refs`），指定项目可用的计算环境。
+
+## ReactFlow 画布
+
+项目详情页以 ReactFlow（`@xyflow/react`）画布展示任务拓扑图。画布包含：
+
+- **Background**：网格背景
+- **Controls**：缩放与适配控件
+- **MiniMap**：缩略图导航
+
+### 节点（TaskNode）
+
+任务节点使用 `TaskNode` 自定义组件，呈现为圆角卡片：
+
+- 左侧状态圆点（queued/starting/running/succeeded/failed/cancelled）
+- 任务标题
+- 环境别名与创建时间
+- 左侧 **target Handle**（输入连接点）
+- 右侧 **source Handle**（输出连接点）
+
+### 边（TaskEdge）
+
+连接线默认类型为 `smoothstep`，带箭头标记（`arrowclosed`）。手动拖拽创建的边使用蓝色描边动画样式。
+
+### 手动连线
+
+1. 从源任务的右侧 source Handle 拖拽
+2. 连线到目标任务的左侧 target Handle
+3. 松开后调用 `createTaskEdge` API 持久化到后端
+
+```typescript
+// 前端自动创建的边数据
+{
+  id: "edge_{source}_{target}",
+  source: source_task_id,
+  target: target_task_id,
+  type: "smoothstep",
+  animated: true,
+}
+```
+
+### 自动连线
+
+当项目任务没有人工连边时，画布按 `created_at` 时间从旧到新自动线性连接所有任务。这些自动边也会异步持久化到后端。
+
+```typescript
+// 自动连线逻辑
+const sorted = [...tasks].sort(
+  (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+);
+// 生成 auto-{prev.id}-{next.id} 边
+```
+
+## 布局
+
+### Dagre 自动布局
+
+首次渲染或点击 "Reset Layout" 时，使用 dagre 算法自动排布节点位置。
+
+### localStorage 持久化
+
+用户手动拖拽节点后，位置信息保存到 `localStorage`，键为 `ainrf:project-layout:{projectId}`。刷新页面后优先恢复已保存的位置。
+
+## 工具栏
+
+画布顶部工具栏包含两个按钮：
+
+- **New Task**：打开任务创建表单
+- **Reset Layout**：清除已保存的布局，触发 dagre 重新排布
+
+### 空态
+
+项目无任务时，画布区域显示空态提示文字，引导用户创建第一个任务。
+
+## 任务创建
+
+TaskCreateForm 表单提供以下配置项：
+
+| 字段         | 说明                           |
+| ------------ | ------------------------------ |
+| 环境         | 选择该项目关联的计算环境       |
+| 工作区       | 选择或输入工作目录             |
+| 技能         | 选择要执行的 AINRF 技能        |
+| 任务配置     | JSON 格式的技能参数            |
+| 引擎类型     | 任务引擎（Python 运行时等）    |
+
+## 关联文档
+
+- [[terminal]]：任务代理终端与会话管理
+- [[workspace]]：工作区与目录管理

--- a/docs/ainrf/quickstart.md
+++ b/docs/ainrf/quickstart.md
@@ -1,0 +1,60 @@
+---
+aliases: [Quick Start, 快速开始, quickstart]
+tags: [ainrf, quickstart]
+---
+
+# 快速开始
+
+## 前置依赖
+
+- Python 3.13+
+- Node.js 22+
+- uv (`pip install uv` 或 `curl -LsSf https://astral.sh/uv/install.sh | sh`)
+
+## 初始化
+
+首次使用必须执行 onboard，创建本地状态与配置：
+
+```bash
+uv run ainrf onboard
+```
+
+## 启动服务
+
+推荐使用 `scripts/webui.sh` 联合启动前后端：
+
+```bash
+scripts/webui.sh        # 生产预览模式 (端口 4173)
+scripts/webui.sh dev    # 开发模式 Vite HMR (端口 5173)
+```
+
+或单独启动后端：
+
+```bash
+uv run ainrf serve
+```
+
+## 默认账户
+
+首次启动时自动创建管理员账户：
+
+- 用户名：`admin`
+- 密码：`admin`
+- 首次登录后提示修改密码
+
+## 访问
+
+| 服务 | 地址 |
+|------|------|
+| WebUI 开发 | `http://localhost:5173` |
+| WebUI 预览 | `http://localhost:4173` |
+| API | `http://localhost:8000` |
+| API 文档 | `http://localhost:8000/docs` |
+
+浏览器通过前端同源代理访问 `/api`、`/code` 与 `/terminal`，无需手动管理 API key。
+
+## 后续步骤
+
+- [[cli]] — CLI 命令详解
+- [[webui]] — WebUI 页面导航
+- [[auth]] — 登录与用户管理

--- a/docs/ainrf/resources.md
+++ b/docs/ainrf/resources.md
@@ -1,0 +1,77 @@
+---
+aliases:
+  - 资源监控
+  - Resource Monitoring
+  - resources
+tags:
+  - ainrf
+  - resources
+  - monitoring
+  - gpu
+  - docs
+  - obsidian-note
+source_repo: scholar-agent
+source_path: docs/ainrf/resources.md
+last_local_commit: workspace aggregate
+---
+
+# 资源监控
+
+> [!abstract]
+> AINRF 资源监控页面提供计算资源的实时可视化，包括 GPU、CPU、内存和 AINRF 进程树，支持本地与远程（SSH）环境。
+
+## ResourcesPage
+
+路由：`/resources`
+
+资源监控页面以 `CardGrid` 布局展示所有环境的资源快照。每个环境一张卡片组，内含系统资源卡（GPU / CPU / 内存）与 AINRF 进程卡两张卡片，支持拖拽排序（布局持久化至 `localStorage`）。
+
+## GPU 监控
+
+通过 `nvidia-smi` 采集 GPU 指标：
+
+- 查询命令：`nvidia-smi --query-gpu=index,name,utilization.gpu,memory.used,memory.total --format=csv`
+- 采集字段：GPU 索引、型号名称（如 NVIDIA A100）、显存使用量（MiB）、显存总量（MiB）、利用率（百分比）
+- 若无 `nvidia-smi` 命令可用，GPU 列表为空
+
+## CPU 监控
+
+通过 `ps` 采集进程级 CPU 数据：
+
+- 查询命令：`ps -eo pid,ppid,pcpu,rss,etime,comm`
+- 采集字段：PID、父 PID、CPU 百分比（单核）、RSS（KB，转换为 MB）、运行耗时、命令名
+- 系统级 CPU 使用率 = 所有进程 CPU 百分比之和 / 逻辑核心数，归一化为 0-100%
+- 通过 `os.cpu_count()` 获取核心数
+
+## 内存监控
+
+通过 `/proc/meminfo` 采集系统内存：
+
+- 读取 `MemTotal` 和 `MemAvailable` 字段
+- 计算：使用量 = MemTotal - MemAvailable
+- 返回：总量（MB）、使用量（MB）、使用百分比
+- 提供异步封装（`anyio.to_thread.run_sync` 避免阻塞事件循环）
+- 读取异常时返回全零值
+
+## 进程树
+
+`ProcessTreeFilter` 以 AINRF 服务进程 PID 为根节点，递归收集所有子进程：
+
+- 通过 `ps -eo pid,ppid,pcpu,rss,etime,comm` 获取全量进程快照
+- 根据 PID-PPID 关系构建树，收集所有后代
+- 返回 `ProcessInfo` 列表：pid、name、cpu_percent、memory_mb、runtime_seconds
+
+根 PID 通过 `os.getpid()` 在 `LocalCollector` 初始化时记录。
+
+## 轮询间隔
+
+资源采集循环每 **2 秒**执行一次（`asyncio.sleep(2)`），每次循环遍历所有已注册环境，逐个采集快照。采集结果缓存在 `ResourceMonitorService._snapshots` 字典中，通过 API 返回给前端。
+
+## 本地与远程环境
+
+- **本地环境**（`env-localhost`）：使用 `LocalCollector`，直接在宿主机上执行 `nvidia-smi` / `ps` / `/proc/meminfo`
+- **远程环境**（SSH）：使用 `RemoteCollector`，通过 `SSHExecutor` 在远端执行相同命令并解析输出
+
+## 关联笔记
+
+- [[index]]

--- a/docs/ainrf/sessions.md
+++ b/docs/ainrf/sessions.md
@@ -1,0 +1,9 @@
+---
+aliases: [sessions, Sessions, 会话追踪]
+tags: [ainrf, sessions, stub]
+---
+
+# 会话追踪
+
+> [!note]
+> 本文档正在编写中。会话追踪记录 Session/Attempt 链、成本与耗时统计。

--- a/docs/ainrf/sessions.md
+++ b/docs/ainrf/sessions.md
@@ -1,9 +1,88 @@
 ---
-aliases: [sessions, Sessions, 会话追踪]
-tags: [ainrf, sessions, stub]
+aliases:
+  - 会话追踪
+  - Sessions
+  - sessions
+tags:
+  - ainrf
+  - sessions
+  - attempts
+  - docs
+  - obsidian-note
+source_repo: scholar-agent
+source_path: docs/ainrf/sessions.md
 ---
 
 # 会话追踪
 
-> [!note]
-> 本文档正在编写中。会话追踪记录 Session/Attempt 链、成本与耗时统计。
+> [!abstract]
+> 会话（Session）是 AINRF 中一次用户交互任务的容器，将多次执行尝试（Attempt）组织为可追溯的链，并聚合成本与耗时统计。
+
+## Session
+
+Session 表示一次用户交互会话，关联一个项目（Project），作为 Attempt 的容器：
+
+| 字段 | 说明 |
+|------|------|
+| `id` | 主键 |
+| `project_id` | 所属项目 |
+| `title` | 会话标题 |
+| `status` | `active` / `completed` / `archived` |
+| `task_count` | 关联任务数量 |
+| `total_duration_ms` | 总耗时（毫秒） |
+| `total_cost_usd` | 总成本（USD） |
+
+### Session 状态
+
+```
+active → completed
+active → archived
+```
+
+## Attempt
+
+Attempt 是 Session 内的单次执行尝试，通过 `parent_attempt_id` 形成 attempt 链，支持中断后继续的场景。
+
+| 字段 | 说明 |
+|------|------|
+| `id` | 主键 |
+| `session_id` | 所属 session |
+| `task_id` | 关联任务（nullable） |
+| `parent_attempt_id` | 父 attempt，形成链式结构 |
+| `attempt_seq` | 序号（1, 2, 3...） |
+| `intervention_reason` | 中断/继续原因 |
+| `status` | `running` / `completed` / `failed` / `interrupted` |
+
+### Attempt 状态
+
+```
+running → completed
+running → failed
+running → interrupted → (下一 attempt)
+```
+
+Attempt 的生命周期由 Task Harness 自动维护：task 从 QUEUED 转为 STARTING 时自动创建 Attempt，task 完成/失败时自动更新对应 Attempt 的状态、耗时和用量数据。
+
+## 成本追踪
+
+Session 表预聚合 `total_cost_usd`（USD 计费）和 `total_duration_ms`（毫秒耗时）两个字段，避免列表页每次查询时实时 JOIN 计算。每次 Attempt 完成后自动 recalculate。
+
+## SessionsPage
+
+WebUI 中通过路由 `/sessions` 访问 SessionsPage，提供：
+
+- **Session 列表**：左侧面板列出所有 session，显示标题、状态、创建时间
+- **Session 详情**：右侧展示 session 下的 Attempt 链，按 seq 排序
+- **筛选**：支持按 `project_id` 和 `status` 参数过滤
+- **时间排序**：列表按创建时间倒序排列
+
+Attempt 链以垂直时间线展示，每个 attempt 卡片显示序号、状态标记、关联任务（可点击跳转）、耗时和中断原因。
+
+## 与 Task 的关联
+
+Task 创建时可绑定 `session_id`，使该 task 的 attempt 自动归入对应 session。Task 详情页中显示所属 session 的链接，TaskCreateForm 提供可选的 session 选择器。
+
+## 关联文档
+
+- [[projects]] — 项目与任务管理
+- [[index]] — AINRF 文档索引

--- a/docs/ainrf/settings.md
+++ b/docs/ainrf/settings.md
@@ -1,0 +1,87 @@
+---
+aliases:
+  - 系统设置
+  - Settings
+  - settings
+tags:
+  - ainrf
+  - settings
+  - admin
+  - users
+  - env-access
+  - collaborators
+  - skill-registry
+  - docs
+  - obsidian-note
+source_repo: scholar-agent
+source_path: docs/ainrf/settings.md
+last_local_commit: workspace aggregate
+---
+
+# 系统设置
+
+> [!abstract]
+> AINRF 设置页面管理用户偏好、系统配置、用户与权限、环境授权以及技能仓库。部分标签页仅管理员可见。
+
+## SettingsPage
+
+路由：`/settings`
+
+设置页面以标签页形式组织，用户偏好（General）对所有用户开放，用户管理、环境授权仅对管理员角色开放。
+
+## General 标签
+
+通用偏好设置，对所有登录用户可见：
+
+- **默认起始页**（Default Route）：登录后的默认跳转页面，可选 Terminal / Tasks / Resources 等
+- **终端字体大小**（Terminal Font Size）：控制 Xterm 终端的字号，支持动态调节
+- **编辑器字体大小**（Editor Font Size）：控制编辑器的字号，支持动态调节（带上下限 clamp）
+- **编辑器字体族**（Editor Font Family）：编辑器的字体选择
+- **默认 Workspace**：任务的默认工作区路径
+- **默认环境**（Default Environment）：任务执行的默认 target environment
+- **默认 Task Profile**：默认的研究 Agent profile ID
+- **Task Input 模板**：创建任务时的默认输入模板
+
+每个偏好项即时保存，有变更提示和重置按钮。
+
+## Users 标签（仅 Admin）
+
+用户管理面板，仅 `admin` 角色可见：
+
+- **用户列表**：列出所有已注册用户，显示用户名、邮箱、角色和状态
+- **审批待定用户**：显示处于 `pending` 状态的用户，管理员可批准或拒绝
+- **激活 / 禁用**：切换用户账户的启用状态
+- **重置密码**：为指定用户生成密码重置令牌
+
+详见 [[auth]]。
+
+## Env Access 标签（仅 Admin）
+
+环境授权管理，仅 `admin` 角色可见：
+
+- **环境授权**：为每个用户授予或撤销特定环境的访问权限
+- **并发任务配额**：配置每个用户的 `max_concurrent_tasks` 上限，限制用户在指定环境中的同时运行任务数
+
+## Collaborators 标签
+
+项目协作者管理：
+
+- **协作者列表**：展示当前项目的所有协作者及其角色
+- **角色**：
+  - **member**（读写）：可以查看、创建和修改项目资源
+  - **viewer**（只读）：仅可查看项目资源，无法创建或修改
+- **添加 / 移除协作者**：支持添加新协作者和调整已有协作者的角色
+
+## Skill Registries
+
+ARIS（AINRF Research Intelligence System）技能仓库管理：
+
+- **仓库列表**：查看已安装的技能仓库源
+- **安装仓库**：添加新的技能仓库 URL
+- **更新仓库**：刷新已安装仓库的技能列表
+- **技能管理**：在仓库中浏览可用技能，查看详情并安装到当前环境
+
+## 关联笔记
+
+- [[auth]]
+- [[index]]

--- a/docs/ainrf/terminal.md
+++ b/docs/ainrf/terminal.md
@@ -1,0 +1,175 @@
+---
+aliases:
+  - AINRF 终端管理
+  - AINRF Terminal
+  - terminal
+tags:
+  - ainrf
+  - terminal
+  - docs
+  - obsidian-note
+source_repo: scholar-agent
+source_path: docs/ainrf/terminal.md
+---
+
+# 终端管理
+
+> [!abstract]
+> AINRF 终端子系统管理 Personal Session（个人终端）和 Agent Session（任务代理终端），支持 Localhost 直连与远程 SSH+tmux 两种模式。
+
+## Session 类型
+
+| 类型            | 用途                     | 生命周期管理              |
+| --------------- | ------------------------ | ------------------------- |
+| Personal Session | 用户手动连接的终端       | `ensure_personal_session` |
+| Agent Session   | 任务代理自动使用的终端   | `ensure_agent_session`    |
+
+每个环境绑定（`UserEnvironmentBinding`）对应一个 session pair，包含 personal 和 agent 两条会话记录。
+
+## 连接模式
+
+### Localhost 环境
+
+当环境的 host 为 `127.0.0.1` 或 `localhost`，且无 proxy_jump/proxy_command 时：
+
+- 跳过 tmux，直接启动 `/bin/bash -l` PTY
+- TIOCSWINSZ resize 直接作用于 shell 进程
+- 持久化由 attachment 生命周期管理
+
+### 远程环境
+
+通过 SSH 连接到远程主机并创建 tmux 会话：
+
+- SSH 连接使用 `~/.ssh/config`、自定义端口、IdentityFile、ProxyJump/ProxyCommand
+- tmux session name 使用 blake2s 哈希生成：`p-{hash}`（personal）或 `a-{hash}`（agent）
+- 远程 tmux 可用性通过 `command -v tmux` 预检
+
+## WebSocket 附件机制
+
+```
+/terminal/attachments/{attachment_id}/ws?token={token}
+```
+
+流程：
+
+1. **创建附件**：`POST /terminal/session` 返回 attachment_id 和过期时间
+2. **WebSocket 连接**：前端使用 attachment_id + token 建立 WebSocket 连接
+3. **PTY 转发**：WebSocket 全双工通道，服务端通过 `os.read`/`os.write` 操作 PTY master fd
+4. **backpressure 控制**：高水位标记暂停 reader，低水位标记恢复
+
+### 消息协议
+
+前端发送 JSON 消息：
+
+```json
+// 输入
+{"type": "input", "data": "ls -la\n"}
+
+// 调整尺寸
+{"type": "resize", "cols": 120, "rows": 40}
+```
+
+服务端发送：
+
+```json
+// 输出
+{"type": "output", "data": "[1m..."}
+
+// 退出状态
+{"type": "status", "status": "exited", "return_code": 0}
+```
+
+### 附件模式
+
+- `INTERACTIVE`：允许键盘输入
+- `OBSERVE`：只读观察，输入消息会被拒绝（关闭连接）
+
+## Session 生命周期
+
+```
+create → attach → detach → reset
+```
+
+### Create
+
+调用 `SessionManager.ensure_personal_session`：
+
+1. 绑定用户与环境（`user_environment_bindings` 表）
+2. 创建 session pair（`user_session_pairs` 表）
+3. 通过 TmuxAdapter 确保 tmux 会话存在
+4. 生成 attachment 目标
+
+### Attach
+
+1. `TerminalAttachmentBroker.create_attachment` 创建附件记录
+2. 记录 attach 时间戳
+3. 返回 attachment_id 供 WebSocket 连接
+
+### Detach
+
+1. `TerminalAttachmentBroker.detach_attachment` 解除附件
+2. 可选的 `SessionManager.reconcile` 刷新本地状态
+
+### Reset
+
+1. `TerminalAttachmentBroker.detach_attachment` 断开当前附件
+2. `TmuxAdapter.kill_session` 杀掉 tmux 会话
+3. `TmuxAdapter.ensure_personal_session` 重新创建 tmux 会话
+4. 生成新附件
+
+## 终端 Resize
+
+WebSocket 收到 `resize` 消息后：
+
+1. `resize_terminal` 调用 `TIOCSWINSZ` ioctl 调整 PTY 尺寸
+2. 调用 `SessionManager.resize_tmux_window` 调整 tmux 窗口尺寸（best-effort）
+3. resize 失败不阻断前端操作
+
+## SessionManager 本地状态
+
+状态存储在 SQLite 数据库中，路径为 `{state_root}/runtime/terminal_state.sqlite3`。
+
+### 核心表
+
+**user_environment_bindings**
+
+| 列               | 说明                         |
+| ---------------- | ---------------------------- |
+| binding_id       | 主键                         |
+| user_id          | 用户 ID                      |
+| environment_id   | 环境 ID                      |
+| remote_login_user | 远程登录用户名               |
+| default_shell    | 默认 shell（如 /bin/bash）   |
+| default_workdir  | 默认工作目录                 |
+| mux_kind         | 终端复用器类型（当前固定 tmux） |
+
+**user_session_pairs**
+
+| 列                  | 说明                          |
+| ------------------- | ----------------------------- |
+| binding_id          | 主键，关联 bindings           |
+| personal_session_name | Personal tmux session 名称  |
+| agent_session_name  | Agent tmux session 名称       |
+| personal_status     | IDLE / RUNNING / FAILED       |
+| agent_status        | IDLE / RUNNING / FAILED       |
+| last_verified_at    | 上次 tmux 状态验证时间        |
+| last_personal_attach_at | 上次个人终端连接时间      |
+| last_agent_attach_at    | 上次代理终端连接时间      |
+
+状态验证：每次读取 pair 时调用 `_refresh_pair` 检查 tmux 会话是否存在，自动更新状态。
+
+## API 端点
+
+| 方法   | 路径                            | 说明                              |
+| ------ | ------------------------------- | --------------------------------- |
+| GET    | `/terminal/session`             | 读取当前 session 记录             |
+| GET    | `/terminal/session-pairs`       | 列出用户的所有 session pairs      |
+| POST   | `/terminal/session`             | 创建/获取 personal session        |
+| DELETE | `/terminal/session`             | 断开附件                          |
+| POST   | `/terminal/session/reset`       | 重置 personal session             |
+| POST   | `/terminal/session/exec`        | 在环境中执行命令（非交互式）      |
+| WS     | `/terminal/attachments/{id}/ws` | WebSocket 终端连接                |
+
+## 关联文档
+
+- [[projects]]：任务代理终端在项目中自动管理

--- a/docs/ainrf/timeline.md
+++ b/docs/ainrf/timeline.md
@@ -1,9 +1,78 @@
 ---
-aliases: [timeline, Timeline, 时间线]
-tags: [ainrf, timeline, stub]
+aliases:
+  - 时间线
+  - Timeline
+  - timeline
+tags:
+  - ainrf
+  - timeline
+  - gantt
+  - docs
+  - obsidian-note
+source_repo: scholar-agent
+source_path: docs/ainrf/timeline.md
 ---
 
 # 时间线
 
-> [!note]
-> 本文档正在编写中。时间线提供 Gantt 图与任务时间分布可视化。
+> [!abstract]
+> 时间线（Timeline）以 Gantt 图形式可视化所有研究会话的时间分布，展示每次尝试的持续时间、状态和成本，支持跨项目筛选。
+
+## Gantt 图
+
+Timeline 页面的核心是一个纯前端的 Gantt 图表，数据完全来自 `GET /sessions` 和 `GET /sessions/{id}` API：
+
+- **左侧标签**：每个 Session 显示为一行，包含标题和迷你统计信息（attempt 数量、总成本）
+- **右侧时间轴**：每个 Attempt 作为一个百分比定位的色块，宽度对应执行时长
+- **交互**：hover 显示 attempt 详情（序号、状态、耗时、成本、中断原因），点击跳转到关联任务
+
+### 定位算法
+
+```
+left  = (attemptStart - minTime) / span * 100  // 百分比定位
+width = max(1, (attemptEnd - attemptStart) / span * 100)  // 最小 1% 保证可见
+```
+
+### 自适应时间轴单位
+
+- 时间跨度 ≤ 24 小时 → 小时刻度
+- 时间跨度 ≤ 7 天 → 天刻度
+- 时间跨度 > 7 天 → 周刻度
+
+## 颜色编码
+
+每个 Attempt 根据状态显示不同颜色：
+
+| 状态 | 颜色 | 含义 |
+|------|------|------|
+| `queued` | 灰色 | 等待执行 |
+| `starting` | 蓝色 | 正在启动 |
+| `running` | 绿色 | 执行中 |
+| `completed` | 深绿色 | 成功完成 |
+| `failed` | 红色 | 执行失败 |
+| `interrupted` | 琥珀色 | 被中断 |
+
+## TimelinePage
+
+路由 `/timeline`，布局包含：
+
+- **TimelineControls**：项目选择器（`GET /projects`）、日期范围选择、快速预设（今天 / 过去 7 天 / 过去 30 天）、当前筛选范围内的 session 数量和总成本摘要
+- **GanttChart**：核心图表组件，包含时间轴表头和逐行渲染的 Gantt 行
+
+## 时间范围缩放与滚动
+
+通过日期范围选择器和快速预设控制可视时间窗口。图表根据筛选结果自动计算最小/最大时间范围，Attempt 色块按百分比在时间轴内定位。轮询间隔为 sessions 15 秒、session details 30 秒。
+
+## 使用场景
+
+Timeline 主要用于可视化多个任务的执行时间分布：
+
+- 对比不同 project 的任务执行模式
+- 追踪中断重试的历史链条
+- 快速识别执行时间异常的任务
+
+## 关联文档
+
+- [[projects]] — 项目与任务管理
+- [[sessions]] — 会话与 Attempt 链
+- [[index]] — AINRF 文档索引

--- a/docs/ainrf/timeline.md
+++ b/docs/ainrf/timeline.md
@@ -1,0 +1,9 @@
+---
+aliases: [timeline, Timeline, 时间线]
+tags: [ainrf, timeline, stub]
+---
+
+# 时间线
+
+> [!note]
+> 本文档正在编写中。时间线提供 Gantt 图与任务时间分布可视化。

--- a/docs/ainrf/webui.md
+++ b/docs/ainrf/webui.md
@@ -1,0 +1,57 @@
+---
+aliases: [WebUI, 前端页面, webui]
+tags: [ainrf, webui, frontend]
+---
+
+# WebUI 总览
+
+## 启动
+
+```bash
+scripts/webui.sh dev     # 开发模式 (Vite HMR, 端口 5173)
+scripts/webui.sh         # 预览模式 (构建后, 端口 4173)
+```
+
+## 架构
+
+- 前端：React 19 + TypeScript + Vite 8
+- UI 组件库：Tailwind CSS v4 + 自定义组件
+- 状态管理：TanStack React Query v5
+- Canvas：@xyflow/react v12 (ReactFlow)
+- 终端：xterm.js
+- 编辑器：Monaco Editor (懒加载)
+
+## 页面路由
+
+| 路由 | 页面 | 说明 |
+|------|------|------|
+| `/login` | LoginPage | 登录 |
+| `/register` | RegisterPage | 注册（新账户需 admin 审批） |
+| `/change-password` | ChangePasswordPage | 修改密码 |
+| `/projects` | ProjectsPage | 项目 Canvas + 任务管理 |
+| `/tasks` | TasksPage | 任务列表与详情 |
+| `/terminal` | TerminalPage | 终端会话 |
+| `/files` | FileBrowserPage | 文件浏览器 |
+| `/sessions` | SessionsPage | 会话追踪 |
+| `/timeline` | TimelinePage | 时间线 (Gantt 图) |
+| `/resources` | ResourcesPage | 资源监控 (GPU/CPU/内存) |
+| `/environments` | EnvironmentsPage | 环境管理 |
+| `/workspaces` | WorkspacesPage | 工作区管理 |
+| `/settings` | SettingsPage | 设置面板 |
+
+## 布局
+
+- 左侧可折叠侧边栏：导航菜单 + 用户信息 + 登出
+- 右侧内容区：当前页面渲染
+- 右侧面板支持拖拽调整宽度（SplitPane）
+
+## 主题
+
+自动跟随系统亮色/暗色模式，使用 CSS 变量实现一致主题。
+
+## 关联笔记
+
+- [[projects]] — 项目 Canvas 详解
+- [[terminal]] — 终端会话
+- [[auth]] — 登录与鉴权
+- [[settings]] — 设置面板

--- a/docs/ainrf/webui.md
+++ b/docs/ainrf/webui.md
@@ -31,7 +31,7 @@ scripts/webui.sh         # 预览模式 (构建后, 端口 4173)
 | `/projects` | ProjectsPage | 项目 Canvas + 任务管理 |
 | `/tasks` | TasksPage | 任务列表与详情 |
 | `/terminal` | TerminalPage | 终端会话 |
-| `/files` | FileBrowserPage | 文件浏览器 |
+| `/workspace-browser` | FileBrowserPage | 文件浏览器 |
 | `/sessions` | SessionsPage | 会话追踪 |
 | `/timeline` | TimelinePage | 时间线 (Gantt 图) |
 | `/resources` | ResourcesPage | 资源监控 (GPU/CPU/内存) |

--- a/docs/ainrf/workspace.md
+++ b/docs/ainrf/workspace.md
@@ -1,9 +1,67 @@
 ---
-aliases: [workspace, Workspace, 工作区管理]
-tags: [ainrf, workspace, stub]
+aliases:
+  - 工作区管理
+  - Workspace
+  - workspace
+tags:
+  - ainrf
+  - workspace
+  - files
+  - editor
+  - docs
+  - obsidian-note
+source_repo: scholar-agent
+source_path: docs/ainrf/workspace.md
 ---
 
 # 工作区管理
 
-> [!note]
-> 本文档正在编写中。工作区管理提供 Workspace 浏览、文件浏览器与 Monaco 编辑器集成。
+> [!abstract]
+> AINRF 工作区（Workspace）是任务执行的目录上下文，包含工作目录定义、系统提示词，并通过文件浏览器提供目录树导航与文件内容查看能力。
+
+## Workspace CRUD
+
+Workspace 通过 REST API 和 WebUI 提供完整的管理操作：
+
+| 操作 | 方法 | API 端点 | 说明 |
+|------|------|----------|------|
+| 列表 | GET | `/workspaces` | 列出当前用户的 workspace，支持 `project_id` 筛选 |
+| 创建 | POST | `/workspaces` | 新建 workspace，需提供 label、workspace_prompt 等字段 |
+| 读取 | GET | `/workspaces/{id}` | 获取单个 workspace 详情 |
+| 更新 | PATCH | `/workspaces/{id}` | 更新 label、description、default_workdir、workspace_prompt |
+| 删除 | DELETE | `/workspaces/{id}` | 删除 workspace（默认 workspace 不可删除，最后一个 workspace 不可删除） |
+
+创建时 `default_workdir` 自动根据 label 生成预设路径，用户可手动修改。
+
+## 默认 Workspace
+
+系统内置 `workspace-default`，指向 `~/.ainrf_workspaces/default` 目录。该 workspace 在服务首次初始化时自动创建，不可被删除，作为新用户的缺省工作区。
+
+## 默认工作目录
+
+每个 workspace 包含一个 `default_workdir` 字段，创建时自动填充为 `~/.ainrf_workspaces/{username}_{slug}` 格式。当任务在此 workspace 下执行时，终端初始目录自动设置为该路径。
+
+## 文件浏览器
+
+文件浏览器位于路由 `/files`，与 workspace 选择器联动：
+
+- **目录树导航**：左侧面板显示目录树，支持展开/折叠、目录切换
+- **文件列表**：右侧展示当前目录下的文件和子目录，显示文件名、大小、修改时间
+- **文件内容查看**：点击文本文件在右侧打开内容预览
+
+### Monaco 编辑器
+
+文本文件通过懒加载的 Monaco Editor 打开，支持语法高亮和代码折叠。大文件不自动加载完整内容。
+
+### 大文件限制
+
+单文件读取超过 50 MB 时，后端返回 `413 Content Too Large` 错误，前端显示文件过大提示。
+
+## 与终端的关系
+
+Workspace 的 `default_workdir` 在任务启动时传递给终端 session，作为初始工作目录。
+
+## 关联文档
+
+- [[terminal]] — 终端 session 与会话管理
+- [[index]] — AINRF 文档索引

--- a/docs/ainrf/workspace.md
+++ b/docs/ainrf/workspace.md
@@ -1,0 +1,9 @@
+---
+aliases: [workspace, Workspace, 工作区管理]
+tags: [ainrf, workspace, stub]
+---
+
+# 工作区管理
+
+> [!note]
+> 本文档正在编写中。工作区管理提供 Workspace 浏览、文件浏览器与 Monaco 编辑器集成。


### PR DESCRIPTION
## Summary
- **13 pages** covering all AINRF subsystems: index, quickstart, CLI, WebUI, auth, projects, terminal, workspace, sessions, timeline, resources, settings, development
- Rewritten `index.md` with full subsystem navigation table
- All wikilinks verified via `build_html_notes.py build`
- Built on top of docs cleanup (stale content archived to `docs/archive/`)

## Test plan
- [x] `uv run python scripts/build_html_notes.py build` passes with 0 errors
- [x] All 13 `docs/ainrf/*.md` files present
- [x] All wikilinks resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)